### PR TITLE
error in _draw_legend

### DIFF
--- a/matplotlib2tikz.py
+++ b/matplotlib2tikz.py
@@ -1251,7 +1251,8 @@ def _draw_legend(data, obj):
     pad = 0.03
     if obj._loc == 1:
         # upper right
-        pass
+        position = None
+        anchor = None
     elif obj._loc == 2:
         # upper left
         position = [pad, 1.0-pad];


### PR DESCRIPTION
'reference before assignment' error when legend is in standard
(upper right) position. Fixed by setting 'position' and 'anchor' to
'None' if 'legend._loc==1'
