### PR TITLE
Add newline at the beginning even if no wrapping is requested

### DIFF
--- a/matplotlib2tikz.py
+++ b/matplotlib2tikz.py
@@ -178,7 +178,7 @@ def save( filepath,
 def _tex_comment( comment ):
     '''Prepends each line in string with the LaTeX comment key, '%'.
     '''
-    return '% ' + str.replace(comment, '\n', '\n% ')
+    return '% ' + str.replace(comment, '\n', '\n% ') + "\n"
 # ==============================================================================
 def _print_tree( obj, indent = '' ):
     '''Recursively prints the tree structure of the matplotlib object.


### PR DESCRIPTION
The missing newline can cause the first real line to be commented out
otherwise. Example snipped with wrap=False before this fix:

% where you can also submit bug reports and leavecomments.
% \begin{axis}[
