### PR TITLE
allow commas in legend entries

### DIFF
--- a/matplotlib2tikz.py
+++ b/matplotlib2tikz.py
@@ -1295,7 +1295,7 @@ def _draw_legend(data, obj):
     for text in obj.texts:
         texts.append( '%s' % text.get_text() )
 
-    cont = 'legend entries={%s}' % ','.join( texts )
+    cont = 'legend entries={{%s}}' % '},{'.join( texts )
     data['extra axis options'].add(cont)
 
     # Get the location.


### PR DESCRIPTION
By wrapping the legend entries in extra braces they can contain commas (','). Otherwise these are misinterpreted as entry separators.
