### PR TITLE
remove newline in output

### DIFF
--- a/matplotlib2tikz.py
+++ b/matplotlib2tikz.py
@@ -175,7 +175,7 @@ def save(filepath,
 
     # write the contents
     if wrap:
-        file_handle.write('\n\\begin{tikzpicture}\n\n')
+        file_handle.write('\\begin{tikzpicture}\n\n')
 
     coldefs = _get_color_definitions(data)
     if coldefs:


### PR DESCRIPTION
The newline in the output before `\begin{tikzpicture}` is interpreted as an actual newline by latex. This, e.g., prevents plots from being placed on the same line.
