### PR TITLE
Change grid style.

### DIFF
--- a/tikzplotlib/axes.py
+++ b/tikzplotlib/axes.py
@@ -305,7 +305,9 @@ class Axes:
             self.axis_options.append("ymajorgrids")
         if obj.yaxis._gridOnMinor:
             self.axis_options.append("yminorgrids")
-
+        
+        self.axis_options.append("grid style=dotted")
+        
         ylines = obj.get_ygridlines()
         if ylines:
             ygridcolor = ylines[0].get_color()


### PR DESCRIPTION
Use dotted grid lines to improve data readability.

It might be a personal preference, but I feel the emphasis on the grid should be reduced.
The grid is merely a visual help and should not draw too much attention.
I have attached two .pdf for comparison: **dotted** grid vs **line** grid.

[dotted_grid.pdf](https://github.com/nschloe/tikzplotlib/files/3663797/dotted_grid.pdf)
[line_grid.pdf](https://github.com/nschloe/tikzplotlib/files/3663798/line_grid.pdf)

Thank you @nschloe for this great library!