### PR TITLE
Get rid of codecs module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import codecs
 import os
 
 from setuptools import find_packages, setup
@@ -10,10 +9,6 @@ with open(os.path.join(base_dir, "tikzplotlib", "__about__.py"), "rb") as f:
     exec(f.read(), about)
 
 
-def read(fname):
-    return codecs.open(os.path.join(base_dir, fname), encoding="utf-8").read()
-
-
 setup(
     name="tikzplotlib",
     version=about["__version__"],
@@ -23,7 +18,7 @@ setup(
     author_email=about["__email__"],
     install_requires=["matplotlib >= 1.4.0", "numpy", "Pillow"],
     description="Convert matplotlib figures into TikZ/PGFPlots",
-    long_description=read("README.md"),
+    long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     license=about["__license__"],
     python_requires=">=3",


### PR DESCRIPTION
Remove the codecs module and replace the obsolete `codecs.open` function by `open` in
Python 3.x