### PR TITLE
Support annotation.textcoords == "offset points"

### DIFF
--- a/test/refresh_reference_files.py
+++ b/test/refresh_reference_files.py
@@ -28,7 +28,7 @@ def _main():
             plt.close()
 
             tex_filename = filename[:-3] + "_reference.tex"
-            with open(os.path.join(this_dir, tex_filename), "w") as f:
+            with open(os.path.join(this_dir, tex_filename), "w", encoding="utf8") as f:
                 f.write(code)
     return
 

--- a/test/test_annotate.py
+++ b/test/test_annotate.py
@@ -26,6 +26,13 @@ def plot():
         textcoords="offset points",
         arrowprops=dict(arrowstyle="->"),
     )
+    ax.annotate(
+        "no arrow",
+        xy=(0, 1),
+        xycoords="data",
+        xytext=(50, -30),
+        textcoords="offset pixels",
+    )
     return fig
 
 

--- a/test/test_annotate_reference.tex
+++ b/test/test_annotate_reference.tex
@@ -39,18 +39,25 @@ table {%
 4.8 0.30901699437495
 };
 \draw[->,red] (axis cs:4.5,1.5) -- (axis cs:4,1);
-\node at (axis cs:4.5,1.5)[
+\draw (axis cs:4.5,1.5) node[
   scale=0.5,
   anchor=base west,
   text=black,
   rotate=0.0
 ]{text};
-\node at (axis cs:-50,30)[
+\draw[->,black] (axis cs:0,1) ++(-50pt,30pt) -- (axis cs:0,1);
+\draw (axis cs:0,1) ++(-50pt,30pt) node[
   scale=0.5,
   anchor=base west,
   text=black,
   rotate=0.0
 ]{arrowstyle};
+\draw (axis cs:0,1) ++(50px,-30px) node[
+  scale=0.5,
+  anchor=base west,
+  text=black,
+  rotate=0.0
+]{no arrow};
 \end{axis}
 
 \end{tikzpicture}

--- a/test/test_arrows_reference.tex
+++ b/test/test_arrows_reference.tex
@@ -27,7 +27,7 @@ ytick style={color=black}
 \draw[draw=none,fill=color0] (axis cs:7.2,1.8) circle (0.2);
 \draw[draw=none,fill=color0] (axis cs:7.2,0.8) circle (0.2);
 \draw[-,black] (axis cs:2,6.8) -- (axis cs:3.2,6.8);
-\node at (axis cs:2,6.8)[
+\draw (axis cs:2,6.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -38,7 +38,7 @@ ytick style={color=black}
   rotate=0.0
 ]{-};
 \draw[->,black] (axis cs:2,5.8) -- (axis cs:3.2,5.8);
-\node at (axis cs:2,5.8)[
+\draw (axis cs:2,5.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -49,7 +49,7 @@ ytick style={color=black}
   rotate=0.0
 ]{-$>$};
 \draw[-|,black] (axis cs:2,4.8) -- (axis cs:3.2,4.8);
-\node at (axis cs:2,4.8)[
+\draw (axis cs:2,4.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -60,7 +60,7 @@ ytick style={color=black}
   rotate=0.0
 ]{-[};
 \draw[-latex,black] (axis cs:2,3.8) -- (axis cs:3.2,3.8);
-\node at (axis cs:2,3.8)[
+\draw (axis cs:2,3.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -71,7 +71,7 @@ ytick style={color=black}
   rotate=0.0
 ]{-$|$$>$};
 \draw[<-,black] (axis cs:2,2.8) -- (axis cs:3.2,2.8);
-\node at (axis cs:2,2.8)[
+\draw (axis cs:2,2.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -82,7 +82,7 @@ ytick style={color=black}
   rotate=0.0
 ]{$<$-};
 \draw[<->,black] (axis cs:2,1.8) -- (axis cs:3.2,1.8);
-\node at (axis cs:2,1.8)[
+\draw (axis cs:2,1.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -93,7 +93,7 @@ ytick style={color=black}
   rotate=0.0
 ]{$<$-$>$};
 \draw[latex-,black] (axis cs:2,0.8) -- (axis cs:3.2,0.8);
-\node at (axis cs:2,0.8)[
+\draw (axis cs:2,0.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -104,7 +104,7 @@ ytick style={color=black}
   rotate=0.0
 ]{$<$$|$-};
 \draw[latex-latex,black] (axis cs:6,6.8) -- (axis cs:7.2,6.8);
-\node at (axis cs:6,6.8)[
+\draw (axis cs:6,6.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -115,7 +115,7 @@ ytick style={color=black}
   rotate=0.0
 ]{$<$$|$-$|$$>$};
 \draw[|-,black] (axis cs:6,5.8) -- (axis cs:7.2,5.8);
-\node at (axis cs:6,5.8)[
+\draw (axis cs:6,5.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -126,7 +126,7 @@ ytick style={color=black}
   rotate=0.0
 ]{]-};
 \draw[|-|,black] (axis cs:6,4.8) -- (axis cs:7.2,4.8);
-\node at (axis cs:6,4.8)[
+\draw (axis cs:6,4.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -137,7 +137,7 @@ ytick style={color=black}
   rotate=0.0
 ]{]-[};
 \draw[-latex,very thick,black] (axis cs:6,3.8) -- (axis cs:7.2,3.8);
-\node at (axis cs:6,3.8)[
+\draw (axis cs:6,3.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -148,7 +148,7 @@ ytick style={color=black}
   rotate=0.0
 ]{fancy};
 \draw[-latex,very thick,black] (axis cs:6,2.8) -- (axis cs:7.2,2.8);
-\node at (axis cs:6,2.8)[
+\draw (axis cs:6,2.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -159,7 +159,7 @@ ytick style={color=black}
   rotate=0.0
 ]{simple};
 \draw[-latex,very thick,black] (axis cs:6,1.8) -- (axis cs:7.2,1.8);
-\node at (axis cs:6,1.8)[
+\draw (axis cs:6,1.8) node[
   scale=0.7,
   fill=white,
   draw=black,
@@ -170,7 +170,7 @@ ytick style={color=black}
   rotate=0.0
 ]{wedge};
 \draw[|-|,black] (axis cs:6,0.8) -- (axis cs:7.2,0.8);
-\node at (axis cs:6,0.8)[
+\draw (axis cs:6,0.8) node[
   scale=0.7,
   fill=white,
   draw=black,

--- a/test/test_fancybox_reference.tex
+++ b/test/test_fancybox_reference.tex
@@ -26,7 +26,7 @@ ytick style={color=black}
 --(axis cs:0.2,0.4)
 .. controls (axis cs:0.2,0.333333333333333) and (axis cs:0.233333333333333,0.3) .. (axis cs:0.3,0.3)
 --cycle;
-\node at (axis cs:0.1,0.8)[
+\draw (axis cs:0.1,0.8) node[
   scale=0.5,
   anchor=base west,
   text=black,
@@ -61,7 +61,7 @@ ytick style={color=black}
 --(axis cs:0.2,0.5)
 .. controls (axis cs:0.2,0.366666666666667) and (axis cs:0.266666666666667,0.3) .. (axis cs:0.4,0.3)
 --cycle;
-\node at (axis cs:0.1,0.8)[
+\draw (axis cs:0.1,0.8) node[
   scale=0.5,
   anchor=base west,
   text=black,
@@ -97,7 +97,7 @@ ytick style={color=black}
 --(axis cs:0.1,0.4)
 .. controls (axis cs:0.1,0.266666666666667) and (axis cs:0.166666666666667,0.2) .. (axis cs:0.3,0.2)
 --cycle;
-\node at (axis cs:0.1,0.8)[
+\draw (axis cs:0.1,0.8) node[
   scale=0.5,
   anchor=base west,
   text=black,
@@ -133,7 +133,7 @@ ytick style={color=black}
 --(axis cs:0,0.4)
 .. controls (axis cs:0,0.3) and (axis cs:0.1,0.25) .. (axis cs:0.3,0.25)
 --cycle;
-\node at (axis cs:0.1,0.8)[
+\draw (axis cs:0.1,0.8) node[
   scale=0.5,
   anchor=base west,
   text=black,

--- a/test/test_subplots_reference.tex
+++ b/test/test_subplots_reference.tex
@@ -124,7 +124,7 @@ table {%
 };
 \end{groupplot}
 
-\node at ({$(current bounding box.south west)!0.5!(current bounding box.south east)$}|-{$(current bounding box.south west)!0.98!(current bounding box.north west)$})[
+\draw ({$(current bounding box.south west)!0.5!(current bounding box.south east)$}|-{$(current bounding box.south west)!0.98!(current bounding box.north west)$}) node[
   scale=0.9,
   anchor=north,
   text=black,

--- a/test/test_text_overlay_reference.tex
+++ b/test/test_text_overlay_reference.tex
@@ -70,7 +70,7 @@ table {%
 5 25
 };
 \addlegendentry{a graph}
-\node at (axis cs:1,5)[
+\draw (axis cs:1,5) node[
   scale=2.5,
   fill=color1,
   draw=color2,
@@ -82,7 +82,7 @@ table {%
   text=red,
   rotate=30.0
 ]{\itshape test1};
-\node at (axis cs:3,6)[
+\draw (axis cs:3,6) node[
   scale=2.5,
   fill=color1,
   draw=color2,
@@ -91,7 +91,7 @@ table {%
   text=blue,
   rotate=330.0
 ]{\bfseries test2};
-\node at (axis cs:4,8)[
+\draw (axis cs:4,8) node[
   fill=color1,
   draw=color2,
   line width=0.4pt,
@@ -101,7 +101,7 @@ table {%
   text=blue,
   rotate=90.0
 ]{\bfseries test3};
-\node at (axis cs:4,16)[
+\draw (axis cs:4,16) node[
   fill=color1,
   draw=color2,
   line width=0.4pt,
@@ -112,7 +112,7 @@ table {%
   text=blue,
   rotate=90.0
 ]{\bfseries test4};
-\node at (axis cs:2,18)[
+\draw (axis cs:2,18) node[
   fill=color1,
   draw=color2,
   line width=0.4pt,
@@ -121,7 +121,7 @@ table {%
   text=blue,
   rotate=0.0
 ]{test5};
-\node at (axis cs:1,20)[
+\draw (axis cs:1,20) node[
   fill=color1,
   draw=color2,
   line width=0.4pt,
@@ -130,7 +130,7 @@ table {%
   text=blue,
   rotate=0.0
 ]{test6};
-\node at (axis cs:3,23)[
+\draw (axis cs:3,23) node[
   fill=color1,
   draw=color2,
   line width=0.4pt,
@@ -140,7 +140,7 @@ table {%
   text=blue,
   rotate=0.0
 ]{test7};
-\node at (axis cs:3,20)[
+\draw (axis cs:3,20) node[
   fill=color1,
   draw=color2,
   line width=0.4pt,


### PR DESCRIPTION
This modifies `_annotation` to return the location at which the text should be rendered, and then adds support for `offset points` and `offset pixels`.

This should make it easier to add support for the other coordinate type too, but I'll leave that for someone who needs them.