### PR TITLE
Ensure absent labels remain absent

### DIFF
--- a/test/test_legend_best_location_reference.tex
+++ b/test/test_legend_best_location_reference.tex
@@ -9,11 +9,13 @@
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.3, xmax=6.3,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.8120665, ymax=2.5603856,
 ytick style={color=black}
@@ -42,14 +44,18 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.03,0.97)}, anchor=north west, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.3, xmax=6.3,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.8120665, ymax=2.5603856,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -75,14 +81,18 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.03,0.03)}, anchor=south west, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.3, xmax=6.3,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.8120665, ymax=2.5603856,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -108,11 +118,13 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.03,0.03)}, anchor=south west, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.3, xmax=6.3,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-2.1214723, ymax=2.1962606,
 ytick style={color=black}
@@ -141,14 +153,18 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.91,0.5)}, anchor=east, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.3, xmax=6.3,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-2.1214723, ymax=2.1962606,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [semithick, color1, forget plot]
 table {%
@@ -192,14 +208,18 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.09,0.5)}, anchor=west, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.3, xmax=6.3,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-2.1214723, ymax=2.1962606,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -296,6 +316,7 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.5,0.91)}, anchor=north, draw=white!80!black},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
@@ -303,7 +324,8 @@ xmin=-0.3, xmax=6.3,
 xtick style={color=black},
 y grid style={white!69.019608!black},
 ymin=-3.3, ymax=3.3,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -328,6 +350,7 @@ table {%
 
 \nextgroupplot[
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, draw=white!80!black},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
@@ -335,7 +358,8 @@ xmin=-0.3, xmax=6.3,
 xtick style={color=black},
 y grid style={white!69.019608!black},
 ymin=-3.3, ymax=3.3,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0, forget plot]
 table {%

--- a/test/test_legends2_reference.tex
+++ b/test/test_legends2_reference.tex
@@ -7,11 +7,13 @@
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.03,0.97)}, anchor=north west, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.08, xmax=1.68,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.0486093, ymax=1.0975528,
 ytick style={color=black}
@@ -53,14 +55,18 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.03,0.03)}, anchor=south west, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.08, xmax=1.68,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.0486093, ymax=1.0975528,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -99,14 +105,18 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.97,0.03)}, anchor=south east, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.08, xmax=1.68,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.0486093, ymax=1.0975528,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -145,11 +155,13 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.97,0.5)}, anchor=east, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.08, xmax=1.68,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.0486093, ymax=1.0975528,
 ytick style={color=black}
@@ -191,14 +203,18 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.09,0.5)}, anchor=west, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.08, xmax=1.68,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.0486093, ymax=1.0975528,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -237,14 +253,18 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.91,0.5)}, anchor=east, draw=white!80!black},
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.08, xmax=1.68,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.0486093, ymax=1.0975528,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -329,6 +349,7 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.5,0.91)}, anchor=north, draw=white!80!black},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
@@ -336,7 +357,8 @@ xmin=-0.08, xmax=1.68,
 xtick style={color=black},
 y grid style={white!69.019608!black},
 ymin=-1.0486093, ymax=1.0975528,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%
@@ -375,6 +397,7 @@ table {%
 \nextgroupplot[
 legend cell align={left},
 legend style={fill opacity=0.8, draw opacity=1, text opacity=1, at={(0.5,0.5)}, anchor=center, draw=white!80!black},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
@@ -382,7 +405,8 @@ xmin=-0.08, xmax=1.68,
 xtick style={color=black},
 y grid style={white!69.019608!black},
 ymin=-1.0486093, ymax=1.0975528,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [very thin, color0]
 table {%

--- a/test/test_sharex_and_y_reference.tex
+++ b/test/test_sharex_and_y_reference.tex
@@ -2,11 +2,13 @@
 
 \begin{groupplot}[group style={group size=2 by 2}]
 \nextgroupplot[
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.245, xmax=5.145,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.1, ymax=1.1,
 ytick style={color=black}
@@ -66,14 +68,18 @@ table {%
 };
 
 \nextgroupplot[
+scaled x ticks=manual:{}{\pgfmathparse{#1}},
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
 xmin=-0.245, xmax=5.145,
 xtick style={color=black},
+xticklabels={},
 y grid style={white!69.019608!black},
 ymin=-1.1, ymax=1.1,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [semithick, red]
 table {%
@@ -194,6 +200,7 @@ table {%
 };
 
 \nextgroupplot[
+scaled y ticks=manual:{}{\pgfmathparse{#1}},
 tick align=outside,
 tick pos=left,
 x grid style={white!69.019608!black},
@@ -201,7 +208,8 @@ xmin=-0.245, xmax=5.145,
 xtick style={color=black},
 y grid style={white!69.019608!black},
 ymin=-1.1, ymax=1.1,
-ytick style={color=black}
+ytick style={color=black},
+yticklabels={}
 ]
 \addplot [semithick, black]
 table {%

--- a/tikzplotlib/_axes.py
+++ b/tikzplotlib/_axes.py
@@ -572,6 +572,12 @@ def _get_ticks(data, xy, ticks, ticklabels):
     for tick in ticks:
         pgfplots_ticks.append(tick)
 
+    # if the labels are all missing, then we need to output an empty set of labels
+    if len(ticklabels) == 0 and len(ticks) != 0:
+        axis_options.append(f"{xy}ticklabels={{}}")
+        # remove the multiplier too
+        axis_options.append(f"scaled {xy} ticks=" + r"manual:{}{\pgfmathparse{#1}}")
+
     # Leave the ticks to PGFPlots if not in STRICT mode and if there are no explicit
     # labels.
     if data["strict"] or is_label_required:


### PR DESCRIPTION

Note lack of labels on the non-edge axes of this plot with shared axes, which matches the matplotlib behavior:

![image](https://user-images.githubusercontent.com/425260/72208736-4b3d3100-349e-11ea-8d80-1bd3fe5aeade.png)
