### PR TITLE
Add support for extra groupstyle options

### DIFF
--- a/tikzplotlib/_axes.py
+++ b/tikzplotlib/_axes.py
@@ -417,9 +417,11 @@ class Axes:
                 # subplotspec geometry positioning is 0-based
                 self.subplot_index = geom[2] + 1
                 if "is_in_groupplot_env" not in data or not data["is_in_groupplot_env"]:
+                    group_style = ["group size={} by {}".format(geom[1], geom[0])]
+                    group_style.extend(data["extra groupstyle options [base]"])
+                    options = ["group style={{{}}}".format(", ".join(group_style))]
                     self.content.append(
-                        "\\begin{{groupplot}}[group style="
-                        "{{group size={} by {}}}]".format(geom[1], geom[0])
+                        "\\begin{{groupplot}}[{}]".format(", ".join(options))
                     )
                     data["is_in_groupplot_env"] = True
                     data["pgfplots libs"].add("groupplots")

--- a/tikzplotlib/_save.py
+++ b/tikzplotlib/_save.py
@@ -27,6 +27,7 @@ def get_tikz_code(
     wrap=True,
     add_axis_environment=True,
     extra_axis_parameters=None,
+    extra_groupstyle_parameters={},
     extra_tikzpicture_parameters=None,
     dpi=None,
     show_info=False,
@@ -174,6 +175,7 @@ def get_tikz_code(
         data["extra axis options [base]"] = set(extra_axis_parameters).copy()
     else:
         data["extra axis options [base]"] = set()
+    data["extra groupstyle options [base]"] = extra_groupstyle_parameters
 
     if dpi:
         data["dpi"] = dpi


### PR DESCRIPTION
The motivation here was to allow
```
extra_groupstyle_parameters={f'horizontal sep={sep}'}
```
As part of something like the following to produce plots that fill the full page width:
```python
    sep = r"\linewidth/24"
    n = len(axs)
    tikzplotlib.save("plot.tikz",
        fig,
        figurewidth=fR'\linewidth/{n} - {n-1}/{n}*{sep}',
        figureheight=fR'\linewidth/{n} - {n-1}/{n}*{sep}',
        extra_tikzpicture_parameters={'trim axis group left', 'trim axis group right'},
        extra_axis_parameters={'scale only axis'},
        extra_groupstyle_parameters={f'horizontal sep={sep}'})
```

An alternative would be to add new arguments specifically for this spacing.