### PR TITLE
fix legend of rectangles by using area instead of ybar

### DIFF
--- a/tikzplotlib/_patch.py
+++ b/tikzplotlib/_patch.py
@@ -149,7 +149,7 @@ def _draw_rectangle(data, obj, draw_options):
 
     if label != "_nolegend_" and label not in data["rectangle_legends"]:
         data["rectangle_legends"].add(label)
-        cont += "\\addlegendimage{{ybar,ybar legend,{}}};\n".format(
+        cont += "\\addlegendimage{{area legend,{}}};\n".format(
             ",".join(draw_options)
         )
         cont += f"\\addlegendentry{{{label}}}\n\n"


### PR DESCRIPTION
Currently, the following code
```python
import matplotlib
matplotlib.use("agg")
import matplotlib.pyplot
import matplotlib.patches
import tikzplotlib

rectangle = matplotlib.patches.Rectangle(
    xy=(0.2, 0.2), width=0.1, height=0.3, label=r"thx\_nschloe"
)

fig, ax = matplotlib.pyplot.subplots()
ax.add_patch(rectangle)
tikzplotlib.save("/tmp/test.tex", standalone=True)
```
produces the following
<img width="597" alt="Screenshot 2020-05-05 at 18 46 14" src="https://user-images.githubusercontent.com/694873/81092449-e56b2e00-8f00-11ea-8cba-8c97bb9dca5d.png">
See the weird legend?

With this fix, we now obtain the following
<img width="595" alt="Screenshot 2020-05-05 at 18 47 15" src="https://user-images.githubusercontent.com/694873/81092521-ff0c7580-8f00-11ea-9ddb-13938b226d8c.png">
