### PR TITLE
Support for opacity of text annotations

### DIFF
--- a/test/test_cleanfigure.py
+++ b/test/test_cleanfigure.py
@@ -1,7 +1,7 @@
 import numpy as np
-import pytest
 from matplotlib import pyplot as plt
 
+import pytest
 from tikzplotlib import clean_figure, get_tikz_code
 
 RC_PARAMS = {"figure.figsize": [5, 5], "figure.dpi": 220, "pgf.rcfonts": False}

--- a/test/test_rotated_labels.py
+++ b/test/test_rotated_labels.py
@@ -1,9 +1,9 @@
 import os
 import tempfile
 
-import pytest
 from matplotlib import pyplot as plt
 
+import pytest
 import tikzplotlib
 
 

--- a/tikzplotlib/_text.py
+++ b/tikzplotlib/_text.py
@@ -246,7 +246,8 @@ def _bbox(bbox, data, properties, scaling):
     properties.append(f"line width={line_width:{ff}}pt")
     inner_sep = bbox_style.pad * data["font size"]
     properties.append(f"inner sep={inner_sep:{ff}}pt")
-    properties.append("fill opacity={}".format(bbox.get_alpha()))
+    if bbox.get_alpha():
+        properties.append("fill opacity={}".format(bbox.get_alpha()))
     # Rounded boxes
     if isinstance(bbox_style, mpl.patches.BoxStyle.Round):
         properties.append("rounded corners")

--- a/tikzplotlib/_text.py
+++ b/tikzplotlib/_text.py
@@ -246,6 +246,7 @@ def _bbox(bbox, data, properties, scaling):
     properties.append(f"line width={line_width:{ff}}pt")
     inner_sep = bbox_style.pad * data["font size"]
     properties.append(f"inner sep={inner_sep:{ff}}pt")
+    properties.append("fill opacity={}".format(bbox.get_alpha()))
     # Rounded boxes
     if isinstance(bbox_style, mpl.patches.BoxStyle.Round):
         properties.append("rounded corners")

--- a/tikzplotlib/_util.py
+++ b/tikzplotlib/_util.py
@@ -13,8 +13,8 @@ def get_legend_text(obj):
     if leg is None:
         return None
 
-    keys = [l.get_label() for l in leg.legendHandles if l is not None]
-    values = [l.get_text() for l in leg.texts]
+    keys = [h.get_label() for h in leg.legendHandles if h is not None]
+    values = [t.get_text() for t in leg.texts]
 
     label = obj.get_label()
     d = dict(zip(keys, values))


### PR DESCRIPTION
The opacity of text annotation boxes is currently ignored. This small addition should take them into account.

It is related to nschloe#198, which resulted in a fix for legends, but not plain text annotations.