### PR TITLE
add missing "mark options={}" for scatter plots

### DIFF
--- a/tikzplotlib/_path.py
+++ b/tikzplotlib/_path.py
@@ -176,9 +176,7 @@ def draw_pathcollection(data, obj):
         )
         draw_options += [f"mark={pgfplots_marker}"]
         if marker_options:
-            draw_options += [
-                "mark options={{{}}}".format(",".join(marker_options))
-            ]
+            draw_options += ["mark options={{{}}}".format(",".join(marker_options))]
 
     # `only mark` plots don't need linewidth
     data, extra_draw_options = get_draw_options(data, obj, ec, fc, ls, None)

--- a/tikzplotlib/_path.py
+++ b/tikzplotlib/_path.py
@@ -174,7 +174,11 @@ def draw_pathcollection(data, obj):
         data, pgfplots_marker, marker_options = _mpl_marker2pgfp_marker(
             data, marker0, fc
         )
-        draw_options += [f"mark={pgfplots_marker}"] + marker_options
+        draw_options += [f"mark={pgfplots_marker}"]
+        if marker_options:
+            draw_options += [
+                "mark options={{{}}}".format(",".join(marker_options))
+            ]
 
     # `only mark` plots don't need linewidth
     data, extra_draw_options = get_draw_options(data, obj, ec, fc, ls, None)


### PR DESCRIPTION
`rotate=X` marker options should be placed defined as `mark options={rotate=X}`
fixes #441 