### PR TITLE
Support for embedding images as base64 with LuaLaTeX

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -72,6 +72,7 @@ def _compile(code, flavor):
     # compile the output to pdf
     cmdline = dict(
         latex=["pdflatex", "--interaction=nonstopmode"],
+        lualatex=["lualatex", "--interaction=nonstopmode"],
         context=["context", "--nonstopmode"],
     )[flavor]
     try:

--- a/test/test_image_plot_embedded.py
+++ b/test/test_image_plot_embedded.py
@@ -1,0 +1,35 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from helpers import assert_equality
+
+
+def plot():
+    fig = plt.figure()
+    ax = plt.axes([0, 0, 1, 1], frameon=False)
+    ax.set_axis_off()
+
+    # a small dummy matrix as image
+
+    img = np.array(
+        [
+            [0, 0, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+            [0, 1, 1, 1],
+        ]
+    )
+
+    plot_image = plt.imshow(img, cmap="viridis")
+
+    # one more line of test coverage
+    plot_image.set_extent(np.array(plot_image.get_extent()))
+
+    return fig
+
+
+def test():
+    assert_equality(
+        plot, "test_image_plot_embedded.tex", flavor="lualatex", embed_images=True
+    )
+    return

--- a/test/test_image_plot_embedded.tex
+++ b/test/test_image_plot_embedded.tex
@@ -1,0 +1,24 @@
+\begin{tikzpicture}
+
+\begin{axis}[
+hide x axis,
+hide y axis,
+tick align=outside,
+tick pos=left,
+x grid style={white!69.019608!black},
+xmin=-0.5, xmax=3.5,
+xtick style={color=black},
+y dir=reverse,
+y grid style={white!69.019608!black},
+ymin=-0.5, ymax=3.5,
+ytick style={color=black}
+]
+\addplot graphics [includegraphics cmd=\pgfimageembedded,xmin=-0.5, xmax=3.5, ymin=3.5, ymax=-0.5] {
+iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90
+bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAA9h
+AAAPYQGoP6dpAAAAJ0lEQVR4nGN0YQz5z4AEmGCMnc8uoAq4Sxkw7Hx2gYEFWZaBgYEBACVJCYDG
+ib9UAAAAAElFTkSuQmCC
+};
+\end{axis}
+
+\end{tikzpicture}

--- a/tikzplotlib/_image.py
+++ b/tikzplotlib/_image.py
@@ -1,3 +1,6 @@
+from base64 import encodebytes
+from io import BytesIO
+
 import matplotlib.pyplot as plt
 import numpy as np
 import PIL
@@ -5,11 +8,46 @@ import PIL
 from . import _files
 
 
+def prepare_image_storage(data):
+    """Prepares a storage location for an image."""
+    if data["embed_images"]:
+        handle = BytesIO()
+        return handle, handle
+    else:
+        filepath, rel_filepath = _files.new_filepath(data, "img", ".png")
+        return filepath, rel_filepath
+
+
+def prepare_image_addplot(data, rel_filepath_or_handle, extent):
+    """Returns an \\addplot command for an image, previously prepared with `prepare_image_storage`."""
+    if not isinstance(rel_filepath_or_handle, BytesIO):
+        # Explicitly use \pgfimage as includegrapics command, as the default
+        # \includegraphics fails unexpectedly in some cases
+        image_embedding_command = "\\pgfimage"
+        image_embedding_parameter = rel_filepath_or_handle
+    else:
+        image_embedding_command = "\\pgfimageembedded"
+        image_embedding_parameter = (
+            "\n" + encodebytes(rel_filepath_or_handle.getbuffer()).decode()
+        )
+
+    # the format specification will only accept tuples
+    if not isinstance(extent, tuple):
+        extent = tuple(extent)
+
+    ff = data["float format"]
+    return (
+        f"\\addplot graphics [includegraphics cmd={image_embedding_command},"
+        f"xmin={extent[0]:{ff}}, xmax={extent[1]:{ff}}, "
+        f"ymin={extent[2]:{ff}}, ymax={extent[3]:{ff}}] {{{image_embedding_parameter}}};\n"
+    )
+
+
 def draw_image(data, obj):
     """Returns the PGFPlots code for an image environment."""
     content = []
 
-    filepath, rel_filepath = _files.new_filepath(data, "img", ".png")
+    filepath_or_handle, rel_filepath_or_handle = prepare_image_storage(data)
 
     # store the image as in a file
     img_array = obj.get_array()
@@ -18,7 +56,7 @@ def draw_image(data, obj):
     if len(dims) == 2:  # the values are given as one real number: look at cmap
         clims = obj.get_clim()
         plt.imsave(
-            fname=filepath,
+            fname=filepath_or_handle,
             arr=img_array,
             cmap=obj.get_cmap(),
             vmin=clims[0],
@@ -40,21 +78,11 @@ def draw_image(data, obj):
         # If the input image is PIL:
         # image = PIL.Image.fromarray(img_array)
 
-        image.save(filepath, origin=obj.origin)
+        image.save(filepath_or_handle, origin=obj.origin, format="PNG")
 
     # write the corresponding information to the TikZ file
     extent = obj.get_extent()
 
-    # the format specification will only accept tuples
-    if not isinstance(extent, tuple):
-        extent = tuple(extent)
+    content.append(prepare_image_addplot(data, rel_filepath_or_handle, extent))
 
-    # Explicitly use \pgfimage as includegrapics command, as the default
-    # \includegraphics fails unexpectedly in some cases
-    ff = data["float format"]
-    content.append(
-        "\\addplot graphics [includegraphics cmd=\\pgfimage,"
-        f"xmin={extent[0]:{ff}}, xmax={extent[1]:{ff}}, "
-        f"ymin={extent[2]:{ff}}, ymax={extent[3]:{ff}}] {{{rel_filepath}}};\n"
-    )
     return data, content


### PR DESCRIPTION
Thanks for this awesome package. I was however a bit unhappy by the fact that image data had to be moved around in separate files, always adding some extra hassle when automatically updating figures from Python. Therefore I created the LuaLaTeX package [luaimageembed](https://ctan.org/pkg/luaimageembed?lang=en), which allows for base64-encoded image files to be decoded on-the-fly and inserted into a document; and the necessary changes to tikzplotlib within this PR. (I had initially developed this for figures in my PhD thesis in 2017, and ported it to current HEAD).

While this might not be everyone's use case, I think people with similar problems would be happy about this possibility.

PS: Coverage browsing on codecov.io currently seems broken.