### PR TITLE
Change behavior for NaN to match matplotlib

### DIFF
--- a/test/test_cleanfigure.py
+++ b/test/test_cleanfigure.py
@@ -115,8 +115,7 @@ class Test_plottypes:
             # Use number of lines to test if it worked.
             numLinesRaw = raw.count("\n")
             numLinesClean = clean.count("\n")
-
-            assert numLinesRaw - numLinesClean == 14
+            assert numLinesRaw - numLinesClean == 13
         plt.close("all")
 
     def test_scatter3d(self):
@@ -569,7 +568,7 @@ class Test_logscale:
             clean = get_tikz_code()
             numLinesRaw = raw.count("\n")
             numLinesClean = clean.count("\n")
-            assert numLinesRaw - numLinesClean == 98
+            assert numLinesRaw - numLinesClean == 99
             assert numLinesClean == 27
         plt.close("all")
 

--- a/tikzplotlib/_line2d.py
+++ b/tikzplotlib/_line2d.py
@@ -274,8 +274,8 @@ def _table(obj, data):  # noqa: C901
     plot_table = []
     table_row_sep = data["table_row_sep"]
     ydata[ydata_mask] = np.nan
-    if any(ydata_mask):
-        # matplotlib jumps at masked images, while PGFPlots by default interpolates.
+    if any(ydata_mask) or (~np.isfinite(ydata)).any():
+        # matplotlib jumps at masked or nan values, while PGFPlots by default interpolates.
         # Hence, if we have a masked plot, make sure that PGFPlots jumps as well.
         if "unbounded coords=jump" not in data["current axes"].axis_options:
             data["current axes"].axis_options.append("unbounded coords=jump")


### PR DESCRIPTION
In [matplotlib](https://matplotlib.org/stable/gallery/lines_bars_and_markers/masked_demo.html), nan values are just ignored, leading to interrupted plots, similar to masked values; by default [pgfplots](http://mirrors.ctan.org/graphics/pgf/contrib/pgfplots/doc/pgfplots.pdf#page=120) however discards them – drawing a line between them, having exactly the opposite behavior.

This PR changes the behavior to match matplotlib's.

I've seen that in `clean_figure()`, NaNs are used; is their usage there based upon the former assumption? In one of the tests which showed different linecount (`test_plot3d()`), I could however not spot any visual difference for the altered variant.