### PR TITLE
Add test case for issue #453

### DIFF
--- a/test/test_errorbar_label.py
+++ b/test/test_errorbar_label.py
@@ -1,0 +1,23 @@
+import matplotlib.pyplot as plt
+from helpers import assert_equality
+
+
+def plot():
+    # plot data
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+
+    x = [0, 1, 2, 3]
+    y1 = [1, 2, 3, 4]
+    y1std = [0.8, 0.5, 0.8, 0.3]
+    y2 = [2, 2, 2, 2]
+    y2std = [0.1, 0.2, 0.3, 0.2]
+
+    ax.errorbar(x, y1, yerr=y1std, label='y1')
+    ax.errorbar(x, y2, yerr=y2std, label='y2')
+    ax.legend()
+    return fig
+
+def test():
+    assert_equality(plot, "test_errorbar_label_reference.tex")
+

--- a/test/test_errorbar_label_reference.tex
+++ b/test/test_errorbar_label_reference.tex
@@ -1,0 +1,75 @@
+\begin{tikzpicture}
+
+\definecolor{color0}{rgb}{0.12156863,0.46666667,0.70588235}
+\definecolor{color1}{rgb}{1,0.49803922,0.054901961}
+
+\begin{axis}[
+legend cell align={left},
+legend style={
+  fill opacity=0.8,
+  draw opacity=1,
+  text opacity=1,
+  at={(0.03,0.97)},
+  anchor=north west,
+  draw=white!80!black
+},
+tick align=outside,
+tick pos=left,
+x grid style={white!69.019608!black},
+xmin=-0.15, xmax=3.15,
+xtick style={color=black},
+y grid style={white!69.019608!black},
+ymin=-0.005, ymax=4.505,
+ytick style={color=black}
+]
+\path [draw=color0, semithick]
+(axis cs:0,0.2)
+--(axis cs:0,1.8);
+
+\path [draw=color0, semithick]
+(axis cs:1,1.5)
+--(axis cs:1,2.5);
+
+\path [draw=color0, semithick]
+(axis cs:2,2.2)
+--(axis cs:2,3.8);
+
+\path [draw=color0, semithick]
+(axis cs:3,3.7)
+--(axis cs:3,4.3);
+
+\path [draw=color1, semithick]
+(axis cs:0,1.9)
+--(axis cs:0,2.1);
+
+\path [draw=color1, semithick]
+(axis cs:1,1.8)
+--(axis cs:1,2.2);
+
+\path [draw=color1, semithick]
+(axis cs:2,1.7)
+--(axis cs:2,2.3);
+
+\path [draw=color1, semithick]
+(axis cs:3,1.8)
+--(axis cs:3,2.2);
+
+\addplot [semithick, color0]
+table {%
+0 1
+1 2
+2 3
+3 4
+};
+\addlegendentry{y1}
+\addplot [semithick, color1]
+table {%
+0 2
+1 2
+2 2
+3 2
+};
+\addlegendentry{y2}
+\end{axis}
+
+\end{tikzpicture}


### PR DESCRIPTION
I've starting debugging #453 and found the place where the bug happens, but I don't know how to fix it.

https://github.com/nschloe/tikzplotlib/blob/dc919b3c538544ecf4b3d86deaf2cb9b80f0af80/tikzplotlib/_util.py#L9

```python
 def get_legend_text(obj): 
    """Check if line is in legend."""
    leg = obj.axes.get_legend()
    if leg is None:
        return None

    # leg.legendHandles = [<matplotlib.collections.LineCollection object at 0x7fc13a90d278>, <matplotlib.collections.LineCollection object at 0x7fc13a90d780>]
    keys = [h.get_label() for h in leg.legendHandles if h is not None] # = ['_nolegend_', '_nolegend_']
    values = [t.get_text() for t in leg.texts] # = ['y1', 'y2']

    # obj = <matplotlib.lines.Line2D object at 0x7fc13c957dd8>
    label = obj.get_label() # = '_nolegend_'
    d = dict(zip(keys, values)) # = {'_nolegend_': 'y2'}
    if label in d:
        return d[label] # Both return the same label

    return None
```

Could you give guidance hints on how to proceed? I think I need to either get from the Line2D object to the LineCollection or vice versa to check if the Line2D is included in the one of the LineCollections.