### PR TITLE
fixed TypeError when using tex_relative_path_to_data

### DIFF
--- a/tikzplotlib/_files.py
+++ b/tikzplotlib/_files.py
@@ -42,4 +42,4 @@ def new_filename(data, file_kind, ext):
     else:
         rel_filepath = name
 
-    return filename, rel_filepath
+    return filename, str(rel_filepath.as_posix())


### PR DESCRIPTION
I think I have a much simpler fix for #472 and the associated commit #473.

This is my first pull request and I'm not a software engineer - please be patient if I don't follow common conventions.

Explanation of the fix:
First, the provided file path `rel_filepath` is converted to a Posix compliant one because (La)TeX follows the Unix style.
The returned value is converted to a `string` since other functions expect it. As this variable is only used for this purpose (within the generated tikz code), it needs no further adjustment in other functions and should have no effect on file processing at the operating system level.

Edit: My first mistake, which I'm already noticing, is that I didn't create a separate branch.