### PR TITLE
Change to only add  option if there is cmap

### DIFF
--- a/src/tikzplotlib/_path.py
+++ b/src/tikzplotlib/_path.py
@@ -112,7 +112,6 @@ def draw_path(data, path, draw_options=None, simplify=None):
 
 def draw_pathcollection(data, obj):
     """Returns PGFPlots code for a number of patch objects."""
-    print("Drawing PathCollection")
     content = []
     # gather data
     assert obj.get_offsets() is not None
@@ -194,7 +193,6 @@ def draw_pathcollection(data, obj):
             ls = None
 
         if add_individual_color_code:
-            print("Adding individual color codes")
             draw_options.extend(
                 [
                     "scatter",
@@ -286,7 +284,6 @@ def draw_pathcollection(data, obj):
 
         # remove duplicates
         draw_options = sorted(list(set(draw_options)))
-        print("Draw options: ", draw_options)
 
         len_row = sum(len(item) for item in draw_options)
         j0, j1, j2 = ("", ", ", "") if len_row < 80 else ("\n  ", ",\n  ", "\n")

--- a/src/tikzplotlib/_path.py
+++ b/src/tikzplotlib/_path.py
@@ -194,6 +194,7 @@ def draw_pathcollection(data, obj):
             ls = None
 
         if add_individual_color_code:
+            print("Adding individual color codes")
             draw_options.extend(
                 [
                     "scatter",
@@ -276,6 +277,7 @@ def draw_pathcollection(data, obj):
                 [
                     "visualization depends on="
                     "{\\thisrow{sizedata} \\as\\perpointmarksize}",
+                    "scatter",
                     "scatter/@pre marker code/.append style="
                     "{/tikz/mark size=\\perpointmarksize}",
                     # "scatter/@post marker code/.style={}"

--- a/src/tikzplotlib/_path.py
+++ b/src/tikzplotlib/_path.py
@@ -112,6 +112,7 @@ def draw_path(data, path, draw_options=None, simplify=None):
 
 def draw_pathcollection(data, obj):
     """Returns PGFPlots code for a number of patch objects."""
+    print("Drawing PathCollection")
     content = []
     # gather data
     assert obj.get_offsets() is not None
@@ -121,13 +122,12 @@ def draw_pathcollection(data, obj):
     fmt = "{:" + data["float format"] + "}"
     dd_strings = np.array([[fmt.format(val) for val in row] for row in dd])
 
-    draw_options = ["scatter", "only marks"]
+    draw_options = ["only marks"]
     table_options = []
 
     is_filled = False
 
     if obj.get_array() is not None:
-        draw_options.append("scatter")
         dd_strings = np.column_stack([dd_strings, obj.get_array()])
         labels.append("colordata")
         draw_options.append("scatter src=explicit")
@@ -138,6 +138,7 @@ def draw_pathcollection(data, obj):
         marker0 = None
         if obj.get_cmap():
             mycolormap, is_custom_cmap = _mpl_cmap2pgf_cmap(obj.get_cmap(), data)
+            draw_options.append("scatter")
             draw_options.append(
                 "colormap" + ("=" if is_custom_cmap else "/") + mycolormap
             )
@@ -283,6 +284,7 @@ def draw_pathcollection(data, obj):
 
         # remove duplicates
         draw_options = sorted(list(set(draw_options)))
+        print("Draw options: ", draw_options)
 
         len_row = sum(len(item) for item in draw_options)
         j0, j1, j2 = ("", ", ", "") if len_row < 80 else ("\n  ", ",\n  ", "\n")

--- a/tests/test_legend_line_scatter_reference.tex
+++ b/tests/test_legend_line_scatter_reference.tex
@@ -21,7 +21,7 @@ y grid style={white!69.019608!black},
 ymin=-0.2, ymax=4.2,
 ytick style={color=black}
 ]
-\addplot [draw=color0, fill=color0, mark=*, only marks, scatter]
+\addplot [draw=color0, fill=color0, mark=*, only marks]
 table{%
 x  y
 0 0

--- a/tests/test_marker_reference.tex
+++ b/tests/test_marker_reference.tex
@@ -15,7 +15,7 @@ ymajorgrids,
 ymin=-1.1, ymax=1.1,
 ytick style={color=black}
 ]
-\addplot [draw=black, fill=black, mark=+, only marks, scatter]
+\addplot [draw=black, fill=black, mark=+, only marks]
 table{%
 x  y
 0 0

--- a/tests/test_scatter_reference.tex
+++ b/tests/test_scatter_reference.tex
@@ -16,7 +16,7 @@ ymajorgrids,
 ymin=0.17184841, ymax=112.81716,
 ytick style={color=black}
 ]
-\addplot [draw=color0, fill=color0, mark=*, only marks, scatter]
+\addplot [draw=color0, fill=color0, mark=*, only marks]
 table{%
 x  y
 0 10.447038


### PR DESCRIPTION
First, thank you for writing and maintaining this marvelous package!

This PR fixes #475 and fixes #479 . It only adds the `scatter` option if there was a colormap specified.