### PR TITLE
Create setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()


### PR DESCRIPTION
Hi, I'm the packager of this module on Arch Linux (https://aur.archlinux.org/packages/python-tikzplotlib). For building the package from source using setuptools a basic `setup.py` is required. The alternative is a very hacky pip call like `PIP_CONFIG_FILE=/dev/null pip install --isolated --root="${pkgdir}" --ignore-installed --no-deps --compile .`

This PR facilitates building this package from source, and prevents downstream from having to ship their own `setup.py`.