### PR TITLE
added more helpful error message when clean_figure fails

### DIFF
--- a/src/tikzplotlib/_cleanfigure.py
+++ b/src/tikzplotlib/_cleanfigure.py
@@ -752,7 +752,9 @@ def _move_points_closer(xLim, yLim, data):
 
     dataInsert = np.array([[]])
     if not _isempty(id_replace):
-        raise NotImplementedError("There is data outside of the box. Don't know how to handle during cleaning. Please check if x/ylim is to tight")
+        raise NotImplementedError(
+            "There is data outside of the box. Don't know how to handle during cleaning. Please check if x/ylim is to tight"
+        )
     data = _insert_data(data, id_replace, dataInsert)
     if _isempty(id_replace):
         return data

--- a/src/tikzplotlib/_cleanfigure.py
+++ b/src/tikzplotlib/_cleanfigure.py
@@ -752,7 +752,7 @@ def _move_points_closer(xLim, yLim, data):
 
     dataInsert = np.array([[]])
     if not _isempty(id_replace):
-        raise NotImplementedError
+        raise NotImplementedError("There is data outside of the box. Don't know how to handle during cleaning. Please check if x/ylim is to tight")
     data = _insert_data(data, id_replace, dataInsert)
     if _isempty(id_replace):
         return data


### PR DESCRIPTION
added more helpful error message when clean_figure fails due to data outside of plot

This may save people some time.

minimal example to raise the error:
```python
import numpy as np
import matplotlib.pyplot as plt


y = np.concatenate([2* np.arange(0,5), np.arange(10,20)])
x = np.arange(len(y))*3
#print(x,y)
plt.plot(x,y)
plt.ylim(5,10)

from src import tikzplotlib

tikzplotlib.clean_figure()
src = tikzplotlib.get_tikz_code()
print(src)
```