### PR TITLE
Escape tex characters in legend (fixes #538)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -1,15 +1,8 @@
 import matplotlib as mpl
 import numpy as np
-from matplotlib.backends.backend_pgf import (
-    common_texification as mpl_common_texification,
-)
 
 from . import _color
-
-
-def _common_texification(string):
-    # Work around <https://github.com/matplotlib/matplotlib/issues/15493>
-    return mpl_common_texification(string).replace("&", "\\&")
+from ._util import _common_texification
 
 
 class Axes:

--- a/src/tikzplotlib/_legend.py
+++ b/src/tikzplotlib/_legend.py
@@ -7,10 +7,8 @@ from . import _color as mycol
 
 def draw_legend(data, obj):
     """Adds legend code."""
-    texts = []
     children_alignment = []
     for text in obj.texts:
-        texts.append(f"{text.get_text()}")
         children_alignment.append(f"{text.get_horizontalalignment()}")
 
     # Get the location.

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -7,7 +7,12 @@ from . import _color as mycol
 from . import _files
 from . import _path as mypath
 from ._markers import _mpl_marker2pgfp_marker
-from ._util import get_legend_text, has_legend, transform_to_data_coordinates
+from ._util import (
+    _common_texification,
+    get_legend_text,
+    has_legend,
+    transform_to_data_coordinates,
+)
 
 
 def draw_line2d(data, obj):
@@ -100,7 +105,7 @@ def draw_line2d(data, obj):
     content += c
 
     if legend_text is not None:
-        content.append(f"\\addlegendentry{{{legend_text}}}\n")
+        content.append(f"\\addlegendentry{{{_common_texification(legend_text)}}}\n")
 
     return data, content
 

--- a/src/tikzplotlib/_patch.py
+++ b/src/tikzplotlib/_patch.py
@@ -2,6 +2,7 @@ import matplotlib as mpl
 
 from . import _path as mypath
 from ._text import _get_arrow_style
+from ._util import _common_texification
 
 
 def draw_patch(data, obj):
@@ -146,7 +147,7 @@ def _draw_rectangle(data, obj, draw_options):
         data["rectangle_legends"].add(label)
         draw_opts = ",".join(draw_options)
         cont += f"\\addlegendimage{{ybar,ybar legend,{draw_opts}}}\n"
-        cont += f"\\addlegendentry{{{label}}}\n\n"
+        cont += f"\\addlegendentry{{{_common_texification(label)}}}\n\n"
     return data, cont
 
 

--- a/src/tikzplotlib/_path.py
+++ b/src/tikzplotlib/_path.py
@@ -7,7 +7,7 @@ from . import _color, _files
 from ._axes import _mpl_cmap2pgf_cmap
 from ._hatches import _mpl_hatch2pgfp_pattern
 from ._markers import _mpl_marker2pgfp_marker
-from ._util import get_legend_text, has_legend
+from ._util import _common_texification, get_legend_text, has_legend
 
 
 def draw_path(data, path, draw_options=None, simplify=None):
@@ -319,7 +319,7 @@ def draw_pathcollection(data, obj):
         content.append("};\n")
 
     if legend_text is not None:
-        content.append(f"\\addlegendentry{{{legend_text}}}\n")
+        content.append(f"\\addlegendentry{{{_common_texification(legend_text)}}}\n")
 
     return data, content
 

--- a/src/tikzplotlib/_util.py
+++ b/src/tikzplotlib/_util.py
@@ -1,5 +1,8 @@
 import matplotlib.transforms
 import numpy as np
+from matplotlib.backends.backend_pgf import (
+    common_texification as mpl_common_texification,
+)
 
 
 def has_legend(axes):
@@ -39,3 +42,8 @@ def transform_to_data_coordinates(obj, xdata, ydata):
         )
         return transform.transform(points).T
     return xdata, ydata
+
+
+def _common_texification(string):
+    # Work around <https://github.com/matplotlib/matplotlib/issues/15493>
+    return mpl_common_texification(string).replace("&", "\\&")

--- a/tests/test_escape_chars.py
+++ b/tests/test_escape_chars.py
@@ -4,10 +4,11 @@ import matplotlib.pyplot as plt
 
 def plot():
     fig = plt.figure()
-    plt.plot(0, 0, "kx")
+    plt.plot(0, 0, "kx", label="Foo & Bar Dogs_N_Cats")
     plt.title("Foo & Bar Dogs_N_Cats")
     plt.xlabel("Foo & Bar Dogs_N_Cats")
     plt.ylabel("Foo & Bar Dogs_N_Cats")
+    plt.gca().legend()
     return fig
 
 

--- a/tests/test_escape_chars_reference.tex
+++ b/tests/test_escape_chars_reference.tex
@@ -1,8 +1,11 @@
 \begin{tikzpicture}
 
 \definecolor{darkgray176}{RGB}{176,176,176}
+\definecolor{lightgray204}{RGB}{204,204,204}
 
 \begin{axis}[
+legend cell align={left},
+legend style={fill opacity=0.8, draw opacity=1, text opacity=1, draw=lightgray204},
 tick align=outside,
 tick pos=left,
 title={Foo \& Bar Dogs\_N\_Cats},
@@ -19,6 +22,7 @@ ytick style={color=black}
 table {%
 0 0
 };
+\addlegendentry{Foo \& Bar Dogs\_N\_Cats}
 \end{axis}
 
 \end{tikzpicture}


### PR DESCRIPTION
* Apply `_common_texification` to legend entries, similar to Axes titles and labels.
* Fix failing pre-commit config due to incompatible dependencies (https://github.com/psf/black/issues/2964)

Fixes #538 