### PR TITLE
Fix shared axis visibility

### DIFF
--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -150,7 +150,7 @@ class Axes:
         bgcolor = obj.get_facecolor()
 
         data, col, _ = _color.mpl_color2xcolor(data, bgcolor)
-        if col != "white":
+        if col != "white" and obj.patch.get_visible():
             self.axis_options.append(f"axis background/.style={{fill={col}}}")
 
         # find color bar
@@ -306,6 +306,12 @@ class Axes:
         else:
             self.axis_options.append(x_tick_position_string)
             self.axis_options.append(y_tick_position_string)
+        
+        # Set global tick size to zero if mpl style does the same (e.g. seaborn-darkgrid)
+        xtick0 = obj.xaxis.get_major_ticks()[0]
+        ytick0 = obj.yaxis.get_major_ticks()[0]
+        if xtick0.get_tick_padding() == ytick0.get_tick_padding() == 0:
+            self.axis_options.append("major tick length=0")
 
     def _grid(self, obj, data):
         # Don't use get_{x,y}gridlines for gridlines; see discussion on

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -290,7 +290,7 @@ def _table(obj, data):  # noqa: C901
 
         opts_str = ("[" + ",".join(opts) + "] ") if len(opts) > 0 else ""
         posix_filepath = rel_filepath.as_posix()
-        content.append(f"table {{{opts_str}}}{{{posix_filepath}}};\n")
+        content.append(f"table {opts_str}{{{posix_filepath}}};\n")
     else:
         if len(opts) > 0:
             opts_str = ",".join(opts)


### PR DESCRIPTION
Secondary axes created via sharex or sharey have an  invisible background.  This is now reflected in the created tex file.

In addition, zero-sized ticks (as for instance produced by the `seaborn` styles) are recognized.