### PR TITLE
Use containers to improve translation of errorbar plot and bar charts

### DIFF
--- a/createBarPlots.py
+++ b/createBarPlots.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Apr 11 22:02:04 2022
+
+@author: Niclas
+"""
+
+from src.tikzplotlib import save
+import matplotlib.pyplot as plt
+import numpy as np
+
+fig = plt.figure()
+ax = fig.add_subplot(111)
+
+
+x = np.array([7.14, 7.36, 7.47, 7.52, 8.3])
+y = np.array([3.3, 4.4, 8.8, 5.5, 9.3])
+# ystd = [0.1, 0.5, 0.8, 0.3]
+ystd = np.array([(0.1,0.2), (0.5,0.1), (0.8,0.3), (0.3, 0.5), (0.3, 0.5)]).transpose()
+xstd = np.array([(np.nan,np.nan), (0.5,0.1), (0.8,0.3), (0.3, 0.5), (0.3, 0.5)]).transpose()
+lolims = [True, None, None, True, None]
+xlolims = [False, None, None, None, None]
+xuplims = [False, None, None, None, None]
+
+eb1 = ax.errorbar(x, y, xerr=0.1, yerr=ystd, ecolor='black', label='1', fmt='d')
+eb2 = ax.errorbar(x+1, y+1, xerr=xstd, yerr=ystd, capsize=3, lolims=lolims, xlolims=xlolims, xuplims=xuplims, label='2')
+eb3 = ax.errorbar(x+2, y+2, xerr=xstd, yerr=ystd, capsize=3, label='3')
+eb4 = ax.errorbar(x+3, y+3, yerr=ystd, capsize=3, label='4')
+
+b6 = ax.bar(x+5,y+5,yerr=ystd, ecolor='green', color= 'red', capsize = 5, label='6')
+plt.legend()
+
+save('testBars.tex',standalone=True, encoding='utf8')

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -150,7 +150,7 @@ class Axes:
         bgcolor = obj.get_facecolor()
 
         data, col, _ = _color.mpl_color2xcolor(data, bgcolor)
-        if col != "white":
+        if col != "white" and obj.patch.get_visible():
             self.axis_options.append(f"axis background/.style={{fill={col}}}")
 
         # find color bar
@@ -306,6 +306,12 @@ class Axes:
         else:
             self.axis_options.append(x_tick_position_string)
             self.axis_options.append(y_tick_position_string)
+        
+        # Set global tick size to zero if mpl style does the same (e.g. seaborn-darkgrid)
+        xtick0 = obj.xaxis.get_major_ticks()[0]
+        ytick0 = obj.yaxis.get_major_ticks()[0]
+        if xtick0.get_tick_padding() == ytick0.get_tick_padding() == 0:
+            self.axis_options.append("major tick length=0")
 
     def _grid(self, obj, data):
         # Don't use get_{x,y}gridlines for gridlines; see discussion on

--- a/src/tikzplotlib/_container.py
+++ b/src/tikzplotlib/_container.py
@@ -1,15 +1,11 @@
 import matplotlib as mpl
-import datetime
 import numpy as np
-from matplotlib.dates import num2date
 from matplotlib.lines import Line2D
 
 from . import _color as mycol
 from ._markers import _mpl_marker2pgfp_marker
-from ._line2d import _marker
+from ._line2d import draw_line2d
 from . import _path as mypath
-from . import _files
-from ._util import get_legend_text, has_legend, transform_to_data_coordinates
 
 def sort(obj):
     if isinstance(obj, mpl.container.BarContainer):
@@ -108,7 +104,7 @@ class ErrorBarContainer(Container):
         """
         Print out the pgfplots commands and options as a list.
         """
-        data, content = draw_line2d_errorbars(data, self.mpl_container[0], self)        
+        data, content = draw_line2d(data, self.mpl_container[0], self)        
         return data, content
 
 
@@ -164,7 +160,7 @@ class BarContainer(Container):
         line_obj.axes = data["current mpl axes obj"]
         line_obj.set_transform(line_obj.axes.transData)
         line_obj.set_color(self.mpl_container[0].get_facecolor())
-        data, content = draw_line2d_errorbars(data, line_obj, self)
+        data, content = draw_line2d(data, line_obj, self)
     
         return data, content
         
@@ -295,225 +291,3 @@ def _collect_error_marker_options(data, obj, marker, line_xcolor, extra_mark_opt
             if xcolor != line_xcolor:
                 content.append(f"{filltype}=" + xcolor)
     return content
-    
-
-def draw_line2d_errorbars(data, obj, container=None):
-    """Returns the PGFPlots code for an Line2D environment."""
-    content = []
-    addplot_options = []
-
-    # If line is of length 0, do nothing.  Otherwise, an empty \addplot table will be
-    # created, which will be interpreted as an external data source in either the file
-    # '' or '.tex'.  Instead, render nothing.
-    xdata = obj.get_xdata()
-    if isinstance(xdata, int) or isinstance(xdata, float):
-        # https://github.com/nschloe/tikzplotlib/issues/339
-        xdata = [xdata]
-
-    if len(xdata) == 0:
-        return data, []
-
-    # get the linewidth (in pt)
-    line_width = mypath.mpl_linewidth2pgfp_linewidth(data, obj.get_linewidth())
-    if line_width:
-        addplot_options.append(line_width)
-
-    # get line color
-    color = obj.get_color()
-    data, line_xcolor, _ = mycol.mpl_color2xcolor(data, color)
-    addplot_options.append(line_xcolor)
-
-    # get draw style
-    drawstyle = obj.get_drawstyle()
-    if drawstyle in [None, "default"]:
-        pass
-    else:
-        if drawstyle == "steps-mid":
-            style = "const plot mark mid"
-        elif drawstyle in ["steps-pre", "steps"]:
-            style = "const plot mark right"
-        else:
-            assert drawstyle == "steps-post"
-            style = "const plot mark left"
-        addplot_options.append(style)
-
-    alpha = obj.get_alpha()
-    if alpha is not None:
-        addplot_options.append(f"opacity={alpha}")
-
-    linestyle = mypath.mpl_linestyle2pgfplots_linestyle(
-        data, obj.get_linestyle(), line=obj
-    )
-    if linestyle is not None and linestyle != "solid":
-        addplot_options.append(linestyle)
-
-    marker_face_color = obj.get_markerfacecolor()
-    marker_edge_color = obj.get_markeredgecolor()
-
-    is_filled = marker_face_color is not None and not (
-        isinstance(marker_face_color, str) and marker_face_color.lower() == "none"
-    )
-    data, marker, extra_mark_options = _mpl_marker2pgfp_marker(
-        data, obj.get_marker(), is_filled
-    )
-    if marker:
-        _marker(
-            obj,
-            data,
-            marker,
-            addplot_options,
-            extra_mark_options,
-            marker_face_color,
-            marker_edge_color,
-            line_xcolor,
-        )
-
-    if marker and linestyle is None:
-        addplot_options.append("only marks")
-
-    # Check if a line is in a legend and forget it if not.
-    # Fixes <https://github.com/nschloe/tikzplotlib/issues/167>.
-    legend_text = get_legend_text(container, data["current mpl axes obj"]) if container else get_legend_text(obj)
-    if legend_text is None and has_legend(data["current mpl axes obj"]):
-        addplot_options.append("forget plot")
-
-    # process options
-    content.append("\\addplot ")
-    if container:
-        addplot_options += container.extra_options + container.errorbar_options
-    opts = ", ".join(addplot_options)
-    content.append(f"[{opts}]\n")
-
-    c, axis_options = _table_errors(obj, data, container.error_data)
-    content += c
-    
-    if legend_text is not None:
-        content.append(f"\\addlegendentry{{{legend_text}}}\n")
-
-    return data, content
-
-def _table_errors(obj, data, error_data=None):  # noqa: C901
-    # get_xydata() always gives float data, no matter what
-    xdata, ydata = obj.get_xydata().T
-
-    # get_{x,y}data gives datetime or string objects if so specified in the plotter
-    xdata_alt = obj.get_xdata()
-    if isinstance(xdata_alt, int) or isinstance(xdata, float):
-        # https://github.com/nschloe/tikzplotlib/issues/339
-        xdata_alt = [xdata_alt]
-
-    ff = data["float format"]
-
-    if isinstance(xdata_alt[0], datetime.datetime):
-        xdata = xdata_alt
-    else:
-        if isinstance(xdata_alt[0], str):
-            data["current axes"].axis_options.append(
-                "xtick={{{}}}".format(",".join([f"{x:{ff}}" for x in xdata])),
-                "xticklabels={{{}}}".format(",".join(xdata_alt)),
-            )
-        xdata, ydata = transform_to_data_coordinates(obj, xdata, ydata)
-
-    # matplotlib allows plotting of data containing `astropy.units`, but they will break
-    # the formatted string here. Try to strip the units from the data.
-    try:
-        xdata = xdata.value
-    except AttributeError:
-        pass
-    try:
-        ydata = ydata.value
-    except AttributeError:
-        pass
-
-    try:
-        _, ydata_alt = obj.get_data()
-        ydata_mask = ydata_alt.mask
-    except AttributeError:
-        ydata_mask = []
-    else:
-        if isinstance(ydata_mask, np.bool_) and not ydata_mask:
-            ydata_mask = []
-        elif callable(ydata_mask):
-            # pandas.Series have the method mask
-            # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.mask.html
-            ydata_mask = []
-
-    axis_options = []
-
-    content = []
-
-    if isinstance(xdata[0], datetime.datetime):
-        xdata = [date.strftime("%Y-%m-%d %H:%M") for date in xdata]
-        xformat = ""
-        col_sep = ","
-        opts = ["header=false", "col sep=comma"]
-        data["current axes"].axis_options.append("date coordinates in=x")
-        # Replace float xmin/xmax by datetime
-        # <https://github.com/matplotlib/matplotlib/issues/13727>.
-        data["current axes"].axis_options = [
-            option
-            for option in data["current axes"].axis_options
-            if not option.startswith("xmin")
-        ]
-        xmin, xmax = data["current mpl axes obj"].get_xlim()
-        mindate = num2date(xmin).strftime("%Y-%m-%d %H:%M")
-        maxdate = num2date(xmax).strftime("%Y-%m-%d %H:%M")
-        data["current axes"].axis_options.append(f"xmin={mindate}, xmax={maxdate}")
-    else:
-        opts = []
-        xformat = ff
-        col_sep = " "
-
-    if data["table_row_sep"] != "\n":
-        # don't want the \n in the table definition, just in the data (below)
-        opts.append("row sep=" + data["table_row_sep"].strip())
-
-    table_row_sep = data["table_row_sep"]
-    ydata[ydata_mask] = np.nan
-    if np.any(ydata_mask) or ~np.all(np.isfinite(ydata)):
-        # matplotlib jumps at masked or nan values, while PGFPlots by default
-        # interpolates. Hence, if we have a masked plot, make sure that PGFPlots jumps
-        # as well.
-        if "unbounded coords=jump" not in data["current axes"].axis_options:
-            data["current axes"].axis_options.append("unbounded coords=jump")
-    
-    ydata_plus_err = [ydata]
-    plot_table = [""]
-    if error_data:
-        opts.extend(["x=x", "y=y"])
-        plot_table[0] += f"x{col_sep}y"
-        for key, value in error_data.items():
-            opts.append(f"{key}={key.replace(' ','')}")
-            plot_table[0] += f"{col_sep}{key.replace(' ','')}"
-            ydata_plus_err.append(value)
-        plot_table[0] += f"{table_row_sep}"
-    
-    for x, *y in zip(xdata, *ydata_plus_err):
-        plot_table.append(f"{x:{xformat}}{col_sep}"+f"{col_sep}".join(f"{y_:{ff}}" for y_ in y)+f"{table_row_sep}")
-        
-
-    min_extern_length = 3
-
-    if data["externalize tables"] and len(xdata) >= min_extern_length:
-        filepath, rel_filepath = _files.new_filepath(data, "table", ".dat")
-        with open(filepath, "w") as f:
-            # No encoding handling required: plot_table is only ASCII
-            f.write("".join(plot_table))
-
-        if data["externals search path"] is not None:
-            esp = data["externals search path"]
-            opts.append(f"search path={{{esp}}}")
-
-        opts_str = ("[" + ",".join(opts) + "] ") if len(opts) > 0 else ""
-        posix_filepath = rel_filepath.as_posix()
-        content.append(f"table {opts_str}{{{posix_filepath}}};\n")
-    else:
-        if len(opts) > 0:
-            opts_str = ",".join(opts)
-            content.append(f"table [{opts_str}] {{%\n")
-        else:
-            content.append("table {%\n")
-        content.extend(plot_table)
-        content.append("};\n")
-
-    return content, axis_options

--- a/src/tikzplotlib/_container.py
+++ b/src/tikzplotlib/_container.py
@@ -163,6 +163,7 @@ class BarContainer(Container):
         line_obj.set_label(self.get_label())
         line_obj.axes = data["current mpl axes obj"]
         line_obj.set_transform(line_obj.axes.transData)
+        line_obj.set_color(self.mpl_container[0].get_facecolor())
         data, content = draw_line2d_errorbars(data, line_obj, self)
     
         return data, content
@@ -284,27 +285,15 @@ def _collect_error_marker_options(data, obj, marker, line_xcolor, extra_mark_opt
     marker_face_color = obj.get_markerfacecolor()
     marker_edge_color = obj.get_markeredgecolor()
     
-    if marker_face_color is None or (
-        isinstance(marker_face_color, str) and marker_face_color == "none"
-    ):
-        content.append("fill opacity=0")
-    else:
-        data, face_xcolor, _ = mycol.mpl_color2xcolor(data, marker_face_color)
-        if face_xcolor != line_xcolor:
-            content.append("fill=" + face_xcolor)
-
-    face_and_edge_have_equal_color = marker_edge_color == marker_face_color
-    # Sometimes, the colors are given as arrays. Collapse them into a
-    # single boolean.
-    try:
-        face_and_edge_have_equal_color = all(face_and_edge_have_equal_color)
-    except TypeError:
-        pass
-
-    if not face_and_edge_have_equal_color:
-        data, draw_xcolor, _ = mycol.mpl_color2xcolor(data, marker_edge_color)
-        if draw_xcolor != line_xcolor:
-            content.append("draw=" + draw_xcolor)
+    for color, filltype in zip([marker_face_color,marker_edge_color], ["fill","draw"]):
+        if color is None or (
+            isinstance(color, str) and color == "none"
+        ):
+            content.append("fill opacity=0")
+        else:
+            data, xcolor, _ = mycol.mpl_color2xcolor(data, color)
+            if xcolor != line_xcolor:
+                content.append(f"{filltype}=" + xcolor)
     return content
     
 

--- a/src/tikzplotlib/_container.py
+++ b/src/tikzplotlib/_container.py
@@ -1,0 +1,404 @@
+import matplotlib as mpl
+import datetime
+import numpy as np
+from matplotlib.dates import num2date
+
+from . import _color as mycol
+from ._markers import _mpl_marker2pgfp_marker
+from ._line2d import _marker
+from . import _path as mypath
+from . import _files
+from ._util import get_legend_text, has_legend, transform_to_data_coordinates
+
+
+def _extract_error_barline_data(data, bar):
+    color = bar.get_edgecolors()[0]
+    style = bar.get_linestyles()[0]
+    width = bar.get_linewidths()[0]
+    paths = bar.get_paths()
+    
+    data, options = mypath.get_draw_options(data, paths[0], color, None, style, width)
+    
+    abs_upper_err, abs_lower_err = [], []
+    for path in paths:
+        errs = path.vertices
+        abs_upper_err.append(max(errs[errs - errs[::-1] != 0]))
+        abs_lower_err.append(min(errs[errs - errs[::-1] != 0]))
+    
+    return data, options, np.array(abs_upper_err), np.array(abs_lower_err)
+    
+
+def draw_container(data, container):
+    
+    if isinstance(container, mpl.container.BarContainer):
+        pass
+    elif isinstance(container, mpl.container.ErrorbarContainer):        
+        
+        # errorbar_options = ['error bars/.cd']
+        errorbar_data = {"general":[]}
+        
+        errorbar_data["label"] = container.get_label()
+        data_line, caplines, barlinecols = container
+        
+        if container.has_xerr or container.has_yerr:
+            errorbar_data["error_data"] = {}
+        
+        if container.has_xerr:
+            bar = barlinecols[0]
+            data, draw_options, xerr_up, xerr_lo = _extract_error_barline_data(data, bar)
+            errorbar_data["error_data"]["x error plus"] = xerr_up - data_line.get_xdata()
+            errorbar_data["error_data"]["x error minus"] = data_line.get_xdata() - xerr_lo
+        if container.has_yerr:
+           if container.has_xerr:
+               bar = barlinecols[1]
+           else:
+               bar = barlinecols[0]
+           data, draw_options, yerr_up, yerr_lo = _extract_error_barline_data(data, bar)
+           errorbar_data["error_data"]["y error plus"] = yerr_up - data_line.get_ydata()
+           errorbar_data["error_data"]["y error minus"] = data_line.get_ydata() - yerr_lo         
+        
+        errorbar_data["style"] = draw_options
+        
+        if not caplines:
+            errorbar_data["general"].append("error mark=none")
+        else:
+            errorbar_data["caps obj"] = caplines[0]
+            
+        data, cont = draw_line2d_errorbars(data, data_line, errorbar_data)
+        zorder = data_line.get_zorder()
+              
+    elif isinstance(container, mpl.container.StemContainer):
+        pass
+    
+    return data, cont, zorder
+
+
+
+def _write_errorbar_options(data, errorbar_data, line_xcolor):
+    def _fill_direction(xy):
+        if f'{xy} error plus' in error_data or f'{xy} error minus' in error_data:
+            content.append(f'{xy} explicit')
+        if f'{xy} error plus' in error_data:
+            if f'{xy} error plus' in error_data:
+                content.append(f'{xy} dir=both')
+            else:
+                content.append(f'{xy} dir=plus, ')
+        elif f'{xy} error minus' in error_data:
+            content.append(f'{xy} dir=minus')
+    
+    content = []
+    content.append('error bars/.cd')
+    content.extend(errorbar_data["general"])
+    error_data = errorbar_data['error_data']
+    for xy in ['x','y']:
+        _fill_direction(xy)
+    content.append(f"error bar style={{{', '.join(errorbar_data['style'])}}}")
+    
+    if "caps obj" in errorbar_data:
+        obj = errorbar_data["caps obj"]
+        marker_face_color = obj.get_markerfacecolor()
+        marker_edge_color = obj.get_markeredgecolor()
+    
+        is_filled = marker_face_color is not None and not (
+            isinstance(marker_face_color, str) and marker_face_color.lower() == "none"
+        )
+        data, marker, extra_mark_options = _mpl_marker2pgfp_marker(
+            data, obj.get_marker(), is_filled
+        )
+        if marker:
+            _error_marker(
+                obj,
+                data,
+                marker,
+                content,
+                extra_mark_options,
+                marker_face_color,
+                marker_edge_color,
+                line_xcolor,
+            )
+    
+    return content
+
+def _error_marker(
+    obj,
+    data,
+    marker,
+    addplot_options,
+    extra_mark_options,
+    marker_face_color,
+    marker_edge_color,
+    line_xcolor,
+):
+    if marker == "-":
+        marker = "|"
+    addplot_options.append("error mark=" + marker)    
+    mark_options = ["solid"]
+    
+    mark_size = obj.get_markersize()
+    if mark_size:
+        ff = data["float format"]
+        # setting half size because pgfplots counts the radius/half-width
+        pgf_size = 0.25 * mark_size
+        mark_options.append(f"mark size={pgf_size:{ff}}")
+
+    mark_every = obj.get_markevery()
+    if mark_every:
+        if type(mark_every) is int:
+            mark_options.append(f"mark repeat={mark_every:d}")
+        else:
+            # python starts at index 0, pgfplots at index 1
+            pgf_marker = [1 + m for m in mark_every]
+            mark_options.append(
+                "mark indices = {" + ", ".join(map(str, pgf_marker)) + "}"
+            )
+
+   
+    mark_options += extra_mark_options
+    if marker_face_color is None or (
+        isinstance(marker_face_color, str) and marker_face_color == "none"
+    ):
+        mark_options.append("fill opacity=0")
+    else:
+        data, face_xcolor, _ = mycol.mpl_color2xcolor(data, marker_face_color)
+        if face_xcolor != line_xcolor:
+            mark_options.append("fill=" + face_xcolor)
+
+    face_and_edge_have_equal_color = marker_edge_color == marker_face_color
+    # Sometimes, the colors are given as arrays. Collapse them into a
+    # single boolean.
+    try:
+        face_and_edge_have_equal_color = all(face_and_edge_have_equal_color)
+    except TypeError:
+        pass
+
+    if not face_and_edge_have_equal_color:
+        data, draw_xcolor, _ = mycol.mpl_color2xcolor(data, marker_edge_color)
+        if draw_xcolor != line_xcolor:
+            mark_options.append("draw=" + draw_xcolor)
+    opts = ", ".join(mark_options)
+    addplot_options.append(f"error mark options={{{opts}}}")
+    
+
+def draw_line2d_errorbars(data, obj, errorbar_data=None):
+    """Returns the PGFPlots code for an Line2D environment."""
+    content = []
+    addplot_options = []
+
+    # If line is of length 0, do nothing.  Otherwise, an empty \addplot table will be
+    # created, which will be interpreted as an external data source in either the file
+    # '' or '.tex'.  Instead, render nothing.
+    xdata = obj.get_xdata()
+    if isinstance(xdata, int) or isinstance(xdata, float):
+        # https://github.com/nschloe/tikzplotlib/issues/339
+        xdata = [xdata]
+
+    if len(xdata) == 0:
+        return data, []
+
+    # get the linewidth (in pt)
+    line_width = mypath.mpl_linewidth2pgfp_linewidth(data, obj.get_linewidth())
+    if line_width:
+        addplot_options.append(line_width)
+
+    # get line color
+    color = obj.get_color()
+    data, line_xcolor, _ = mycol.mpl_color2xcolor(data, color)
+    addplot_options.append(line_xcolor)
+
+    # get draw style
+    drawstyle = obj.get_drawstyle()
+    if drawstyle in [None, "default"]:
+        pass
+    else:
+        if drawstyle == "steps-mid":
+            style = "const plot mark mid"
+        elif drawstyle in ["steps-pre", "steps"]:
+            style = "const plot mark right"
+        else:
+            assert drawstyle == "steps-post"
+            style = "const plot mark left"
+        addplot_options.append(style)
+
+    alpha = obj.get_alpha()
+    if alpha is not None:
+        addplot_options.append(f"opacity={alpha}")
+
+    linestyle = mypath.mpl_linestyle2pgfplots_linestyle(
+        data, obj.get_linestyle(), line=obj
+    )
+    if linestyle is not None and linestyle != "solid":
+        addplot_options.append(linestyle)
+
+    marker_face_color = obj.get_markerfacecolor()
+    marker_edge_color = obj.get_markeredgecolor()
+
+    is_filled = marker_face_color is not None and not (
+        isinstance(marker_face_color, str) and marker_face_color.lower() == "none"
+    )
+    data, marker, extra_mark_options = _mpl_marker2pgfp_marker(
+        data, obj.get_marker(), is_filled
+    )
+    if marker:
+        _marker(
+            obj,
+            data,
+            marker,
+            addplot_options,
+            extra_mark_options,
+            marker_face_color,
+            marker_edge_color,
+            line_xcolor,
+        )
+
+    if marker and linestyle is None:
+        addplot_options.append("only marks")
+
+    # Check if a line is in a legend and forget it if not.
+    # Fixes <https://github.com/nschloe/tikzplotlib/issues/167>.
+    legend_text = get_legend_text(obj)
+    if legend_text is None and has_legend(obj.axes):
+        addplot_options.append("forget plot")
+
+    # process options
+    content.append("\\addplot ")
+    if errorbar_data:
+        addplot_options.extend(_write_errorbar_options(data, errorbar_data, line_xcolor))
+    if addplot_options:
+        opts = ", ".join(addplot_options)
+        content.append(f"[{opts}]\n")
+
+    c, axis_options = _table_errors(obj, data, errorbar_data)
+    content += c
+    
+    if errorbar_data and "label" in errorbar_data:
+        content.append(f"\\addlegendentry{{{errorbar_data['label']}}}\n")
+    elif legend_text is not None:
+        content.append(f"\\addlegendentry{{{legend_text}}}\n")
+
+    return data, content
+
+def _table_errors(obj, data, errorbar_data=None):  # noqa: C901
+    # get_xydata() always gives float data, no matter what
+    xdata, ydata = obj.get_xydata().T
+
+    # get_{x,y}data gives datetime or string objects if so specified in the plotter
+    xdata_alt = obj.get_xdata()
+    if isinstance(xdata_alt, int) or isinstance(xdata, float):
+        # https://github.com/nschloe/tikzplotlib/issues/339
+        xdata_alt = [xdata_alt]
+
+    ff = data["float format"]
+
+    if isinstance(xdata_alt[0], datetime.datetime):
+        xdata = xdata_alt
+    else:
+        if isinstance(xdata_alt[0], str):
+            data["current axes"].axis_options += [
+                "xtick={{{}}}".format(",".join([f"{x:{ff}}" for x in xdata])),
+                "xticklabels={{{}}}".format(",".join(xdata_alt)),
+            ]
+        xdata, ydata = transform_to_data_coordinates(obj, xdata, ydata)
+
+    # matplotlib allows plotting of data containing `astropy.units`, but they will break
+    # the formatted string here. Try to strip the units from the data.
+    try:
+        xdata = xdata.value
+    except AttributeError:
+        pass
+    try:
+        ydata = ydata.value
+    except AttributeError:
+        pass
+
+    try:
+        _, ydata_alt = obj.get_data()
+        ydata_mask = ydata_alt.mask
+    except AttributeError:
+        ydata_mask = []
+    else:
+        if isinstance(ydata_mask, np.bool_) and not ydata_mask:
+            ydata_mask = []
+        elif callable(ydata_mask):
+            # pandas.Series have the method mask
+            # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.mask.html
+            ydata_mask = []
+
+    axis_options = []
+
+    content = []
+
+    if isinstance(xdata[0], datetime.datetime):
+        xdata = [date.strftime("%Y-%m-%d %H:%M") for date in xdata]
+        xformat = ""
+        col_sep = ","
+        opts = ["header=false", "col sep=comma"]
+        data["current axes"].axis_options.append("date coordinates in=x")
+        # Replace float xmin/xmax by datetime
+        # <https://github.com/matplotlib/matplotlib/issues/13727>.
+        data["current axes"].axis_options = [
+            option
+            for option in data["current axes"].axis_options
+            if not option.startswith("xmin")
+        ]
+        xmin, xmax = data["current mpl axes obj"].get_xlim()
+        mindate = num2date(xmin).strftime("%Y-%m-%d %H:%M")
+        maxdate = num2date(xmax).strftime("%Y-%m-%d %H:%M")
+        data["current axes"].axis_options.append(f"xmin={mindate}, xmax={maxdate}")
+    else:
+        opts = []
+        xformat = ff
+        col_sep = " "
+
+    if data["table_row_sep"] != "\n":
+        # don't want the \n in the table definition, just in the data (below)
+        opts.append("row sep=" + data["table_row_sep"].strip())
+
+    table_row_sep = data["table_row_sep"]
+    ydata[ydata_mask] = np.nan
+    if np.any(ydata_mask) or ~np.all(np.isfinite(ydata)):
+        # matplotlib jumps at masked or nan values, while PGFPlots by default
+        # interpolates. Hence, if we have a masked plot, make sure that PGFPlots jumps
+        # as well.
+        if "unbounded coords=jump" not in data["current axes"].axis_options:
+            data["current axes"].axis_options.append("unbounded coords=jump")
+    
+    ydata_plus_err = [ydata]
+    plot_table = [""]
+    if errorbar_data and "error_data" in errorbar_data:
+        opts.extend(["x=x", "y=y"])
+        plot_table[0] += f"x{col_sep}y"
+        for key, value in errorbar_data["error_data"].items():
+            opts.append(f"{key}={key.replace(' ','')}")
+            plot_table[0] += f"{col_sep}{key.replace(' ','')}"
+            ydata_plus_err.append(value)
+        plot_table[0] += f"{table_row_sep}"
+    
+    for x, *y in zip(xdata, *ydata_plus_err):
+        plot_table.append(f"{x:{xformat}}{col_sep}"+f"{col_sep}".join(f"{y_:{ff}}" for y_ in y)+f"{table_row_sep}")
+        
+
+    min_extern_length = 3
+
+    if data["externalize tables"] and len(xdata) >= min_extern_length:
+        filepath, rel_filepath = _files.new_filepath(data, "table", ".dat")
+        with open(filepath, "w") as f:
+            # No encoding handling required: plot_table is only ASCII
+            f.write("".join(plot_table))
+
+        if data["externals search path"] is not None:
+            esp = data["externals search path"]
+            opts.append(f"search path={{{esp}}}")
+
+        opts_str = ("[" + ",".join(opts) + "] ") if len(opts) > 0 else ""
+        posix_filepath = rel_filepath.as_posix()
+        content.append(f"table {opts_str}{{{posix_filepath}}};\n")
+    else:
+        if len(opts) > 0:
+            opts_str = ",".join(opts)
+            content.append(f"table [{opts_str}] {{%\n")
+        else:
+            content.append("table {%\n")
+        content.extend(plot_table)
+        content.append("};\n")
+
+    return content, axis_options

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -290,7 +290,7 @@ def _table(obj, data):  # noqa: C901
 
         opts_str = ("[" + ",".join(opts) + "] ") if len(opts) > 0 else ""
         posix_filepath = rel_filepath.as_posix()
-        content.append(f"table {{{opts_str}}}{{{posix_filepath}}};\n")
+        content.append(f"table {opts_str}{{{posix_filepath}}};\n")
     else:
         if len(opts) > 0:
             opts_str = ",".join(opts)

--- a/src/tikzplotlib/_save.py
+++ b/src/tikzplotlib/_save.py
@@ -34,6 +34,7 @@ def get_tikz_code(
     extra_groupstyle_parameters: dict = {},
     extra_tikzpicture_parameters: list | set | None = None,
     extra_lines_start: list | set | None = None,
+    use_containers: bool = True,
     dpi: int | None = None,
     show_info: bool = False,
     include_disclaimer: bool = True,
@@ -109,6 +110,11 @@ def get_tikz_code(
     :param extra_tikzpicture_parameters: Extra tikzpicture options to be passed
                                          (as a set) to pgfplots.
     :type extra_tikzpicture_parameters: a set of strings for the pfgplots tikzpicture.
+    
+    :param use_containers: Enable or disable the use of mpl containers to create the
+                            corresponding pgfplots styles for errorbars, bar charts
+                            and stem plots.
+    :type use_containers: bool
 
     :param dpi: The resolution in dots per inch of the rendered image in case
                 of QuadMesh plots. If ``None`` it will default to the value
@@ -177,6 +183,7 @@ def get_tikz_code(
     data["legend colors"] = []
     data["add axis environment"] = add_axis_environment
     data["show_info"] = show_info
+    data["use containers"] = use_containers
     # rectangle_legends is used to keep track of which rectangles have already
     # had \addlegendimage added. There should be only one \addlegenimage per
     # bar chart data series.
@@ -328,13 +335,13 @@ def _draw_collection(data, child):
     else:
         return _patch.draw_patchcollection(data, child)
 
-
-def _recurse(data, obj):
+def _recurse(data, obj, containers=None):
     """Iterates over all children of the current object, gathers the contents
     contributing to the resulting PGFPlots file, and returns those.
     """
     content = _ContentManager()
-    for child in obj.get_children():
+    containers = [] if containers is None else containers
+    for child in containers + obj.get_children():
         # Some patches are Spines, too; skip those entirely.
         # See <https://github.com/nschloe/tikzplotlib/issues/277>.
         if isinstance(child, mpl.spines.Spine) or child in data["container elements"]:
@@ -353,20 +360,16 @@ def _recurse(data, obj):
             data["current mpl axes obj"] = child
             data["current axes"] = ax
             
-            errorbar_content = []
-            for container in child.containers:
-                data, cont, zorder = _container.draw_container(data, container)
-                errorbar_content.extend(cont)
-                data["container elements"].update(container.get_children())
-
+            if data['use containers']:
+                containers = sorted(child.containers, key=_container.sort)
+            
             # Run through the child objects, gather the content.
-            data, children_content = _recurse(data, child)
+            data, children_content = _recurse(data, child, containers)
 
             # populate content and add axis environment if desired
             if data["add axis environment"]:
                 content.extend(
-                    ax.get_begin_code() + errorbar_content 
-                    + children_content + [ax.get_end_code(data)], 0
+                    ax.get_begin_code() + children_content + [ax.get_end_code(data)], 0
                 )
             else:
                 content.extend(children_content, 0)
@@ -376,6 +379,9 @@ def _recurse(data, obj):
                     print("These would have been the properties of the environment:")
                     print("".join(ax.get_begin_code()[1:]))
                     print("=========================================================")
+        elif isinstance(child, mpl.container.Container):
+            data, cont, zorder = _container.draw_container(data, child)
+            content.extend(cont, zorder)
         elif isinstance(child, mpl.lines.Line2D):
             data, cont = _line2d.draw_line2d(data, child)
             content.extend(cont, child.get_zorder())

--- a/src/tikzplotlib/_util.py
+++ b/src/tikzplotlib/_util.py
@@ -6,9 +6,11 @@ def has_legend(axes):
     return axes.get_legend() is not None
 
 
-def get_legend_text(obj):
+def get_legend_text(obj, axes=None):
     """Check if line is in legend."""
-    leg = obj.axes.get_legend()
+    if axes is None:
+        axes = obj.axes
+    leg = axes.get_legend()
     if leg is None:
         return None
 
@@ -16,9 +18,9 @@ def get_legend_text(obj):
     values = [t.get_text() for t in leg.texts]
 
     label = obj.get_label()
-    d = dict(zip(keys, values))
-    if label in d:
-        return d[label]
+    for key,value in zip(keys,values):
+        if (label == key != "_nolegend_") or (key == "_nolegend_" and label == value):
+            return value
 
     return None
 


### PR DESCRIPTION
As suggested years ago [here](https://github.com/texworld/tikzplotlib/issues/218#issuecomment-648001407), I finally got around to implement some code that adds support for translating the container objects used by matplotlib for errorbars and bar charts to create pgfplots with the corresponding `error bars` and `ybar`/`xbar` styles. 

The new functionality and the resulting tex output can be tested via the `createBarPlots.py` script.

Key advantages:

- error bar plots and bar charts are plotted as a single `\addplot` command, greatly improving readability of the tex file and the possibility of later fine-tuning from latex.
- repeated legend entries for every error bar feature as shown in https://github.com/texworld/tikzplotlib/issues/218 are avoided. Although legend representation in the resulting tex is not 1:1 as what is shown in matplotlib, I would consider it better than before. This should at least fix https://github.com/texworld/tikzplotlib/issues/453 and all related issues. 

Although I tried to touch as little as possible of the existing code base, I realize that this is quite an intrusive PR, so don't hesitate to suggest any improvements or alterations that should be made. https://github.com/texworld/tikzplotlib/commit/d8182d5ee07d15065c9afa2953be2a73db624080 is optional, as it integrates the required changes into the original `draw_line2d` and `_table` instead of defining (mostly redundant) alternatives to be used with the containers.

Tests would of course need to be adjusted, that's why I would consider this WIP for the moment until you could have  a first look. 