### PR TITLE
Add support for axes.Axes._tikzplotlib_anchors

### DIFF
--- a/src/tikzplotlib/_save.py
+++ b/src/tikzplotlib/_save.py
@@ -141,9 +141,9 @@ def get_tikz_code(
     The following optional attributes of matplotlib's objects are recognized
     and handled:
 
-     - axes.Axes._tikzplotlib_anchors
+     - `axes.Axes._tikzplotlib_anchors`
        This attribute can be set to a list of ((x,y), anchor_name) tuples.
-       Invisible nodes at the respective location will be created which  can be
+       Invisible nodes at the respective location will be created which can be
        referenced from outside the axis environment.
     """
     # not as default value because gcf() would be evaluated at import time

--- a/src/tikzplotlib/_save.py
+++ b/src/tikzplotlib/_save.py
@@ -351,6 +351,10 @@ def _recurse(data, obj):
             # Run through the child objects, gather the content.
             data, children_content = _recurse(data, child)
 
+            if hasattr(child, "_tikzplotlib_anchors"):
+                for (x, y), anchor_name in child._tikzplotlib_anchors:
+                    children_content.append(f"\\coordinate ({anchor_name}) at ({x},{y});\n")
+
             # populate content and add axis environment if desired
             if data["add axis environment"]:
                 content.extend(

--- a/src/tikzplotlib/_save.py
+++ b/src/tikzplotlib/_save.py
@@ -353,7 +353,7 @@ def _recurse(data, obj):
 
             if hasattr(child, "_tikzplotlib_anchors"):
                 for (x, y), anchor_name in child._tikzplotlib_anchors:
-                    children_content.append(f"\\coordinate ({anchor_name}) at ({x},{y});\n")
+                    children_content.append(f"\\coordinate ({anchor_name}) at (axis cs:{x},{y});\n")
 
             # populate content and add axis environment if desired
             if data["add axis environment"]:

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -4,7 +4,9 @@ def plot():
     fig = plt.figure()
     plt.plot([1, 2, 3], [4, -2, 3])
     ax = plt.gca()
-    ax._tikzplotlib_anchors = [((1.5, 2.5), "foo")]
+    ax._tikzplotlib_anchors = [
+        ((1.5, 2.5), "foo"),
+    ]
     return fig
 
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -6,6 +6,7 @@ def plot():
     ax = plt.gca()
     ax._tikzplotlib_anchors = [
         ((1.5, 2.5), "foo"),
+        ((0.4, 1.3), "bar"),
     ]
     return fig
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -1,0 +1,14 @@
+def plot():
+    from matplotlib import pyplot as plt
+
+    fig = plt.figure()
+    plt.plot([1, 2, 3], [4, -2, 3])
+    ax = plt.gca()
+    ax._tikzplotlib_anchors = [((1.5, 2.5), "foo")]
+    return fig
+
+
+def test():
+    from .helpers import assert_equality
+
+    assert_equality(plot, __file__[:-3] + "_reference.tex")

--- a/tests/test_coordinates_reference.tex
+++ b/tests/test_coordinates_reference.tex
@@ -20,7 +20,7 @@ table {%
 2 -2
 3 3
 };
-\coordinate (foo) at (1.5,2.5);
+\coordinate (foo) at (axis cs:1.5,2.5);
 \end{axis}
 
 \end{tikzpicture}

--- a/tests/test_coordinates_reference.tex
+++ b/tests/test_coordinates_reference.tex
@@ -1,0 +1,26 @@
+% This file was created with tikzplotlib v0.10.1.
+\begin{tikzpicture}
+
+\definecolor{darkgray176}{RGB}{176,176,176}
+\definecolor{steelblue31119180}{RGB}{31,119,180}
+
+\begin{axis}[
+tick align=outside,
+tick pos=left,
+x grid style={darkgray176},
+xmin=0.9, xmax=3.1,
+xtick style={color=black},
+y grid style={darkgray176},
+ymin=-2.3, ymax=4.3,
+ytick style={color=black}
+]
+\addplot [semithick, steelblue31119180]
+table {%
+1 4
+2 -2
+3 3
+};
+\coordinate (foo) at (1.5,2.5);
+\end{axis}
+
+\end{tikzpicture}

--- a/tests/test_coordinates_reference.tex
+++ b/tests/test_coordinates_reference.tex
@@ -21,6 +21,7 @@ table {%
 3 3
 };
 \coordinate (foo) at (axis cs:1.5,2.5);
+\coordinate (bar) at (axis cs:0.4,1.3);
 \end{axis}
 
 \end{tikzpicture}


### PR DESCRIPTION
The documentation mentions support for a `_tikzplotlib_anchors` attribute on matplotlib Axes() objects to add custom anchors in the plot (very useful to refer back to from custom tikz code outside the auto-generated one, e.g. to add additional content from the outside). However, this isn't actually supported in the code. This PR adds a minimal implementation; I'd be happy to discuss how to improve it!

Example Python code:
```python
import matplotlib.pyplot as plt
plt.plot([1,2,3], [4,-2,3])
ax = plt.gca()
ax._tikzplotlib_anchors = [((1.5, 2.5), "foo")]
import tikzplotlib as tikz
tikz.save("test.tex")
```
Resulting generated output:
```latex
% This file was created with tikzplotlib v0.10.1.
\begin{tikzpicture}

\definecolor{darkgray176}{RGB}{176,176,176}
\definecolor{steelblue31119180}{RGB}{31,119,180}

\begin{axis}[
tick align=outside,
tick pos=left,
x grid style={darkgray176},
xmin=0.9, xmax=3.1,
xtick style={color=black},
y grid style={darkgray176},
ymin=-2.3, ymax=4.3,
ytick style={color=black}
]
\addplot [semithick, steelblue31119180]
table {%
1 4
2 -2
3 3
};
\coordinate (foo) at (1.5,2.5);
\end{axis}

\end{tikzpicture}
```
Note the additional `\coordinate (foo) at (1.5,2.5);` line.