### PR TITLE
Legend Compatibility Issue in `_legend.py` for `obj.ncols` (Matplotlib 3.6.0 Update)

### DIFF
--- a/src/tikzplotlib/_legend.py
+++ b/src/tikzplotlib/_legend.py
@@ -78,8 +78,13 @@ def draw_legend(data, obj):
     if alignment:
         data["current axes"].axis_options.append(f"legend cell align={{{alignment}}}")
 
-    if obj._ncols != 1:
-        data["current axes"].axis_options.append(f"legend columns={obj._ncol}")
+    try:
+        ncols = obj._ncols
+    except AttributeError:
+        # backwards-compatibility with matplotlib < 3.6.0
+        ncols = obj._ncol
+    if ncols != 1:
+        data["current axes"].axis_options.append(f"legend columns={ncols}")
 
     # Write styles to data
     if legend_style:

--- a/src/tikzplotlib/_legend.py
+++ b/src/tikzplotlib/_legend.py
@@ -78,7 +78,7 @@ def draw_legend(data, obj):
     if alignment:
         data["current axes"].axis_options.append(f"legend cell align={{{alignment}}}")
 
-    if obj._ncol != 1:
+    if obj._ncols != 1:
         data["current axes"].axis_options.append(f"legend columns={obj._ncol}")
 
     # Write styles to data


### PR DESCRIPTION
I'm no expert in any of this but I've tried the fix suggested in #557, seems to work in some test cases I've tried. Maybe just an overlooked detail? 

(Apparently `_ncol` is outdated now as per [Matplotlib API Docs](https://matplotlib.org/stable/api/legend_api.html), but I left line 82 as is in case anything else goes wrong)