### PR TITLE
Changed object.ncol to object.ncols

### DIFF
--- a/src/tikzplotlib/_legend.py
+++ b/src/tikzplotlib/_legend.py
@@ -78,8 +78,8 @@ def draw_legend(data, obj):
     if alignment:
         data["current axes"].axis_options.append(f"legend cell align={{{alignment}}}")
 
-    if obj._ncol != 1:
-        data["current axes"].axis_options.append(f"legend columns={obj._ncol}")
+    if obj._ncols != 1:
+        data["current axes"].axis_options.append(f"legend columns={obj._ncols}")
 
     # Write styles to data
     if legend_style:


### PR DESCRIPTION
Since matplotlib=3.6 matplotlib.legend attribute  ncol was renamed to ncols. Renaming in the _legend.py file solves this error.