### PR TITLE
Clean Figure: Handle case if all data is nan

### DIFF
--- a/src/tikzplotlib/_cleanfigure.py
+++ b/src/tikzplotlib/_cleanfigure.py
@@ -486,6 +486,8 @@ def _remove_NaNs(data):
     :returns: data without NaNs
     """
     id_nan = np.any(np.isnan(data), axis=1)
+    if np.all(id_nan):
+        return np.delete(data, np.arange(len(data)), axis=0)
     id_remove = np.argwhere(id_nan).reshape((-1,))
     if _isempty(id_remove):
         pass


### PR DESCRIPTION
I noticed a bug in `_remove_NaNs`.

the faulty code:

```python
    id_nan = np.any(np.isnan(data), axis=1)
    (....)

    id_first = np.argwhere(np.logical_not(id_nan))[0]
```

I have a plot where data is `array([[nan, nan]], dtype=float32)`, which results in `np.argwhere(np.logical_not(id_nan))` returning `array([], shape=(0, 1), dtype=int64)`. Therefore taking `np.argwhere(np.logical_not(id_nan))[0]` results in an index out of bounds exception (there is no first index).

This fixes the problem.
