### PR TITLE
Rename ncol parameter to ncols

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = ["latex", "tikz", "matplotlib", "graphics"]
 dynamic = ["version"]
 requires-python = ">=3.7"
 dependencies = [
-  "matplotlib >= 1.4.0",
+  "matplotlib >= 3.6.0",
   "numpy",
   "Pillow",
   "webcolors",

--- a/src/tikzplotlib/_legend.py
+++ b/src/tikzplotlib/_legend.py
@@ -78,8 +78,8 @@ def draw_legend(data, obj):
     if alignment:
         data["current axes"].axis_options.append(f"legend cell align={{{alignment}}}")
 
-    if obj._ncol != 1:
-        data["current axes"].axis_options.append(f"legend columns={obj._ncol}")
+    if obj._ncols != 1:
+        data["current axes"].axis_options.append(f"legend columns={obj._ncols}")
 
     # Write styles to data
     if legend_style:


### PR DESCRIPTION
Following [this PR](https://github.com/matplotlib/matplotlib/commit/958e329b198a9036fc121d11775815ded7c9acad) in matplotlib (v3.6.0 released in sept. 2022), _ncol was renamed _ncols.