### PR TITLE
fix typo in _legend.py : obj.ncol should be obj.ncols

### DIFF
--- a/src/tikzplotlib/_legend.py
+++ b/src/tikzplotlib/_legend.py
@@ -78,8 +78,8 @@ def draw_legend(data, obj):
     if alignment:
         data["current axes"].axis_options.append(f"legend cell align={{{alignment}}}")
 
-    if obj._ncol != 1:
-        data["current axes"].axis_options.append(f"legend columns={obj._ncol}")
+    if obj._ncols != 1:
+        data["current axes"].axis_options.append(f"legend columns={obj._ncols}")
 
     # Write styles to data
     if legend_style:


### PR DESCRIPTION
This fixes an AttributeError when a user calls `plt.legend()` and then saves a figure with `tikzplotlib.save`. Since `obj` in the relevant line is of type `matplotlib.legend.Legend()`, the attribute is `ncols` and not `ncol` (see https://matplotlib.org/stable/api/legend_api.html#matplotlib.legend.Legend).