### PR TITLE
Update _legend.py

### DIFF
--- a/src/tikzplotlib/_legend.py
+++ b/src/tikzplotlib/_legend.py
@@ -78,8 +78,8 @@ def draw_legend(data, obj):
     if alignment:
         data["current axes"].axis_options.append(f"legend cell align={{{alignment}}}")
 
-    if obj._ncol != 1:
-        data["current axes"].axis_options.append(f"legend columns={obj._ncol}")
+    if obj._ncols != 1:
+        data["current axes"].axis_options.append(f"legend columns={obj._ncols}")
 
     # Write styles to data
     if legend_style:


### PR DESCRIPTION
Possible typo: `_ncol` instead of `n_cols`.
With `_ncol` calling `tikzplotlib.save()` on a plot containing legends results in the error:
```
Traceback (most recent call last):
  File "/home/marvin/phd_scripts/2023_04_14 picoscope/analyzepicoscope_class.py", line 36, in <module>
    tikzplotlib.save("picoscope.tikz")
  File "/home/marvin/.local/lib/python3.10/site-packages/tikzplotlib/_save.py", line 262, in save
    code = get_tikz_code(*args, filepath=filepath, **kwargs)
  File "/home/marvin/.local/lib/python3.10/site-packages/tikzplotlib/_save.py", line 213, in get_tikz_code
    data, content = _recurse(data, figure)
  File "/home/marvin/.local/lib/python3.10/site-packages/tikzplotlib/_save.py", line 352, in _recurse
    data, children_content = _recurse(data, child)
  File "/home/marvin/.local/lib/python3.10/site-packages/tikzplotlib/_save.py", line 380, in _recurse
    data = _legend.draw_legend(data, child)
  File "/home/marvin/.local/lib/python3.10/site-packages/tikzplotlib/_legend.py", line 81, in draw_legend
    if obj._ncol != 1:
AttributeError: 'Legend' object has no attribute '_ncol'. Did you mean: '_ncols'?

```