### PR TITLE
Sync dash pattern change for matplotlib >= 3.6.0

### DIFF
--- a/src/tikzplotlib/_path.py
+++ b/src/tikzplotlib/_path.py
@@ -469,8 +469,12 @@ def mpl_linestyle2pgfplots_linestyle(data, line_style, line=None):
         default_dashOffset, default_dashSeq = mpl.lines._get_dash_pattern(line_style)
 
         # get dash format of line under test
-        dashSeq = line._us_dashSeq
-        dashOffset = line._us_dashOffset
+        try:
+            dashOffset, dashSeq = line._unscaled_dash_pattern[:2]
+        except AttributeError:
+            # backwards-compatibility with matplotlib < 3.6.0
+            dashSeq = line._us_dashSeq
+            dashOffset = line._us_dashOffset
 
         lst = list()
         if dashSeq != default_dashSeq:


### PR DESCRIPTION
This fixes #580, which has been broken since the *matplotlib* change in https://github.com/matplotlib/matplotlib/pull/21050/commits/9c0fa9ed83a825eb34ae8d44ba1b4123145f8422 for version 3.6.0.

This PR is similar to #571, but has two differences:

* It keeps the backwards-compatibility for older *matplotlib* versions.
* It uses the unscaled dash patterns as indicated by the old `_us_` variable name, while #571 apparently switched to the scaled one.