### PR TITLE
fix #559 for `matplotlib >= 3.6`

### DIFF
--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -1,15 +1,13 @@
 import matplotlib as mpl
 import numpy as np
-from matplotlib.backends.backend_pgf import (
-    common_texification as mpl_common_texification,
-)
+from matplotlib.backends.backend_pgf import _tex_escape as mpl_tex_escape
 
 from . import _color
 
 
-def _common_texification(string):
+def _tex_escape(string):
     # Work around <https://github.com/matplotlib/matplotlib/issues/15493>
-    return mpl_common_texification(string).replace("&", "\\&")
+    return mpl_tex_escape(string).replace("&", "\\&")
 
 
 class Axes:
@@ -42,13 +40,13 @@ class Axes:
         title = obj.get_title()
         data["current axis title"] = title
         if title:
-            title = _common_texification(title)
+            title = _tex_escape(title)
             self.axis_options.append(f"title={{{title}}}")
 
         # get axes titles
         xlabel = obj.get_xlabel()
         if xlabel:
-            xlabel = _common_texification(xlabel)
+            xlabel = _tex_escape(xlabel)
 
             labelcolor = obj.xaxis.label.get_c()
 
@@ -64,7 +62,7 @@ class Axes:
 
         ylabel = obj.get_ylabel()
         if ylabel:
-            ylabel = _common_texification(ylabel)
+            ylabel = _tex_escape(ylabel)
 
             labelcolor = obj.yaxis.label.get_c()
             if labelcolor != "black":
@@ -594,7 +592,7 @@ def _get_ticks(data, xy, ticks, ticklabels):
         label = ticklabel.get_text()
         if "," in label:
             label = "{" + label + "}"
-        pgfplots_ticklabels.append(_common_texification(label))
+        pgfplots_ticklabels.append(_tex_escape(label))
 
     # note: ticks may be present even if labels are not, keep them for grid lines
     for tick in ticks:


### PR DESCRIPTION
This replaces the `_common_texification` deprecated by `Matplotlib 3.6` with `_tex_escape`. I also changed the name in `tikzplotlib` accordingly.

This should fix #559.