### PR TITLE
 replacing deprecated mpl function `common_texification` with `_tex_escape`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup
+
+setup(
+    name='tikzplotlib',
+    packages=['tikzplotlib'],
+    package_dir={'':'src'}
+)

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -20,6 +20,7 @@ def _siunitx_texification(string: str) -> str:
     string = re.sub(r"\sAngstrom", r" \\si{\\angstrom}", string)
     string = re.sub(r"\sg/s", r" \\si{\\gram\\per\\second}", string)
     string = re.sub(r"\shour", r" \\si{\\hour}", string)
+    string = re.sub(r"(\d+(\.\d+)?)\s?cc", r"\\SI{\1}{\\cc}", string)
     string = re.sub(r"\scc", r" \\si{\\cc}", string)
     string = re.sub(r"\s\\%", r" \\si{\\percent}", string)
     string = re.sub(r"\sg/um", r" \\si{\\g\\per\\um}", string)

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -1,5 +1,6 @@
 import matplotlib as mpl
 import numpy as np
+import re
 from matplotlib.backends.backend_pgf import (
     common_texification as mpl_common_texification,
 )
@@ -51,7 +52,7 @@ class Axes:
             xlabel = _common_texification(xlabel)
 
             labelcolor = obj.xaxis.label.get_c()
-
+            xlabel = re.sub(r"\smm", r" \\si{\\mm}", xlabel)
             if labelcolor != "black":
                 data, col, _ = _color.mpl_color2xcolor(data, labelcolor)
                 self.axis_options.append(f"xlabel=\\textcolor{{{col}}}{{{xlabel}}}")

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -239,6 +239,8 @@ class Axes:
         else:
             # TODO keep an eye on https://tex.stackexchange.com/q/480058/13262
             pass
+        if data["axis_equal"]:
+            self.axis_options.append("axis equal")
 
     def _ticks(self, data, obj):
         # get ticks

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -354,6 +354,8 @@ class Axes:
             self.axis_options.append("xmajorgrids")
         if has_minor_xgrid:
             self.axis_options.append("xminorgrids")
+            # No way to check from the axis the actual style of the minor grid
+            self.axis_options.append("minor x grid style={gray!20}")
 
         xlines = obj.get_xgridlines()
         if xlines:
@@ -366,6 +368,8 @@ class Axes:
             self.axis_options.append("ymajorgrids")
         if has_minor_ygrid:
             self.axis_options.append("yminorgrids")
+            # No way to check from the axis the actual style of the minor grid
+            self.axis_options.append("minor y grid style={gray!20}")
 
         ylines = obj.get_ygridlines()
         if ylines:

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -24,6 +24,7 @@ def _siunitx_texification(string: str) -> str:
     string = re.sub(r"\scc", r" \\si{\\cc}", string)
     string = re.sub(r"\s\\%", r" \\si{\\percent}", string)
     string = re.sub(r"\sg/um", r" \\si{\\g\\per\\um}", string)
+    string = re.sub(r"(\d+(\.\d+)?)\s?deg", r"\\SI{\1}{\\degree}", string)
     return string
 
 

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -12,6 +12,16 @@ def _common_texification(string):
     # Work around <https://github.com/matplotlib/matplotlib/issues/15493>
     return mpl_common_texification(string).replace("&", "\\&")
 
+def _siunitx_texification(string: str) -> str:
+    string = re.sub(r"\smm", r" \\si{\\mm}", string)
+    string = re.sub(r"\s°C", r" \\si{\\celsius}", string)
+    string = re.sub(r"\sA/s", r" \\si{\\angstrom\\per\\second}", string)
+    string = re.sub(r"\sg/s", r" \\si{\\gram\\per\\second}", string)
+    string = re.sub(r"\shour", r" \\si{\\hour}", string)
+    string = re.sub(r"\scc", r" \\si{\\cc}", string)
+    string = re.sub(r"\s\\%", r" \\si{\\percent}", string)
+    return string
+
 
 class Axes:
     def __init__(self, data, obj):  # noqa: C901
@@ -50,9 +60,9 @@ class Axes:
         xlabel = obj.get_xlabel()
         if xlabel:
             xlabel = _common_texification(xlabel)
+            xlabel = _siunitx_texification(xlabel)
 
             labelcolor = obj.xaxis.label.get_c()
-            xlabel = re.sub(r"\smm", r" \\si{\\mm}", xlabel)
             xlabel_spl = xlabel.split(",")
             if len(xlabel_spl) == 2:
                 xlabel = ",".join(["$" + xlabel_spl[0].replace(" ", "\\ ") + "$",
@@ -71,10 +81,13 @@ class Axes:
         ylabel = obj.get_ylabel()
         if ylabel:
             ylabel = _common_texification(ylabel)
+            ylabel = _siunitx_texification(ylabel)
 
             ylabel_spl = ylabel.split(",")
             if len(ylabel_spl) == 2:
-                ylabel = ",".join(["$" + ylabel_spl[0].replace(" ", "\\ ") + "$",
+                ylabel = ",".join(["$" + ylabel_spl[0].replace(" ",
+                    "\\ ").replace("+-", r"\pm").replace("-",
+                    r"\mhyphen ") + "$",
                                    ylabel_spl[1]])
 
             labelcolor = obj.yaxis.label.get_c()

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -2,16 +2,14 @@ import matplotlib as mpl
 import math
 import numpy as np
 import re
-from matplotlib.backends.backend_pgf import (
-    common_texification as mpl_common_texification,
-)
+from matplotlib.backends.backend_pgf import _tex_escape as mpl_tex_escape
 
 from . import _color
 
 
-def _common_texification(string):
+def _tex_escape(string):
     # Work around <https://github.com/matplotlib/matplotlib/issues/15493>
-    return mpl_common_texification(string).replace("&", "\\&")
+    return mpl_tex_escape(string).replace("&", "\\&")
 
 def _siunitx_texification(string: str) -> str:
     string = re.sub(r"\smm", r" \\si{\\mm}", string)
@@ -58,14 +56,14 @@ class Axes:
         title = obj.get_title()
         data["current axis title"] = title
         if title:
-            title = _common_texification(title)
+            title = _tex_escape(title)
             title = _siunitx_texification(title)
             self.axis_options.append(f"title={{{title}}}")
 
         # get axes titles
         xlabel = obj.get_xlabel()
         if xlabel:
-            xlabel = _common_texification(xlabel)
+            xlabel = _tex_escape(xlabel)
             xlabel = _siunitx_texification(xlabel)
 
             labelcolor = obj.xaxis.label.get_c()
@@ -86,7 +84,7 @@ class Axes:
 
         ylabel = obj.get_ylabel()
         if ylabel:
-            ylabel = _common_texification(ylabel)
+            ylabel = _tex_escape(ylabel)
             ylabel = _siunitx_texification(ylabel)
 
             ylabel_spl = ylabel.split(",")
@@ -630,7 +628,7 @@ def _get_ticks(data, xy, ticks, ticklabels):
         label = ticklabel.get_text()
         if "," in label:
             label = "{" + label + "}"
-        pgfplots_ticklabels.append(_common_texification(label))
+        pgfplots_ticklabels.append(_tex_escape(label))
 
     # note: ticks may be present even if labels are not, keep them for grid lines
     for tick in ticks:

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -53,6 +53,11 @@ class Axes:
 
             labelcolor = obj.xaxis.label.get_c()
             xlabel = re.sub(r"\smm", r" \\si{\\mm}", xlabel)
+            xlabel_spl = xlabel.split(",")
+            if len(xlabel_spl) == 2:
+                xlabel = ",".join(["$" + xlabel_spl[0].replace(" ", "\\ ") + "$",
+                                   xlabel_spl[1]])
+
             if labelcolor != "black":
                 data, col, _ = _color.mpl_color2xcolor(data, labelcolor)
                 self.axis_options.append(f"xlabel=\\textcolor{{{col}}}{{{xlabel}}}")
@@ -66,6 +71,11 @@ class Axes:
         ylabel = obj.get_ylabel()
         if ylabel:
             ylabel = _common_texification(ylabel)
+
+            ylabel_spl = ylabel.split(",")
+            if len(ylabel_spl) == 2:
+                ylabel = ",".join(["$" + ylabel_spl[0].replace(" ", "\\ ") + "$",
+                                   ylabel_spl[1]])
 
             labelcolor = obj.yaxis.label.get_c()
             if labelcolor != "black":

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -58,6 +58,7 @@ class Axes:
         data["current axis title"] = title
         if title:
             title = _common_texification(title)
+            title = _siunitx_texification(title)
             self.axis_options.append(f"title={{{title}}}")
 
         # get axes titles

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -21,6 +21,7 @@ def _siunitx_texification(string: str) -> str:
     string = re.sub(r"\shour", r" \\si{\\hour}", string)
     string = re.sub(r"\scc", r" \\si{\\cc}", string)
     string = re.sub(r"\s\\%", r" \\si{\\percent}", string)
+    string = re.sub(r"\sg/um", r" \\si{\\g\\per\\um}", string)
     return string
 
 

--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -17,6 +17,7 @@ def _siunitx_texification(string: str) -> str:
     string = re.sub(r"\smm", r" \\si{\\mm}", string)
     string = re.sub(r"\s°C", r" \\si{\\celsius}", string)
     string = re.sub(r"\sA/s", r" \\si{\\angstrom\\per\\second}", string)
+    string = re.sub(r"\sAngstrom", r" \\si{\\angstrom}", string)
     string = re.sub(r"\sg/s", r" \\si{\\gram\\per\\second}", string)
     string = re.sub(r"\shour", r" \\si{\\hour}", string)
     string = re.sub(r"\scc", r" \\si{\\cc}", string)

--- a/src/tikzplotlib/_legend.py
+++ b/src/tikzplotlib/_legend.py
@@ -78,8 +78,11 @@ def draw_legend(data, obj):
     if alignment:
         data["current axes"].axis_options.append(f"legend cell align={{{alignment}}}")
 
-    if obj._ncol != 1:
-        data["current axes"].axis_options.append(f"legend columns={obj._ncol}")
+    try:
+        if obj._ncol != 1:
+            data["current axes"].axis_options.append(f"legend columns={obj._ncol}")
+    except AttributeError:
+        warnings.warn("Unable to interrogate the number of columns in legend. Using 1 as default.")
 
     # Write styles to data
     if legend_style:

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -1,13 +1,13 @@
 import datetime
 
 import numpy as np
-import re
 from matplotlib.dates import num2date
 
 from . import _color as mycol
 from . import _files
 from . import _path as mypath
 from ._markers import _mpl_marker2pgfp_marker
+from ._text import escape_text
 from ._util import get_legend_text, has_legend, transform_to_data_coordinates
 
 
@@ -101,12 +101,7 @@ def draw_line2d(data, obj):
     content += c
 
     if legend_text is not None:
-        legend_text_escaped = re.sub(r"(\d+(\.\d+)?)\s?%",
-                                     r"\\SI{\1}{\\percent}",
-                                     legend_text).replace("+-\\SI{",
-                                     "\\SI{+-").replace(", s",
-                                     ", \\SI{\s}")
-        content.append(f"\\addlegendentry{{{legend_text_escaped}}}\n")
+        content.append(f"\\addlegendentry{{{escape_text(legend_text)}}}\n")
 
     return data, content
 

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -1,6 +1,7 @@
 import datetime
 
 import numpy as np
+import re
 from matplotlib.dates import num2date
 
 from . import _color as mycol
@@ -100,7 +101,8 @@ def draw_line2d(data, obj):
     content += c
 
     if legend_text is not None:
-        content.append(f"\\addlegendentry{{{legend_text}}}\n")
+        legend_text_escaped = re.sub(r"(\d+(\.\d+)?)%", r"\\SI{\1}{\\percent}", legend_text)
+        content.append(f"\\addlegendentry{{{legend_text_escaped}}}\n")
 
     return data, content
 

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -273,10 +273,15 @@ def _table(obj, data):  # noqa: C901
         if "unbounded coords=jump" not in data["current axes"].axis_options:
             data["current axes"].axis_options.append("unbounded coords=jump")
 
-    plot_table = [
-        f"{x:{xformat}}{col_sep}{y:{ff}}{table_row_sep}" for x, y in zip(
-            xdata[::data["every n dot"]], ydata[::data["every n dot"]])
-    ]
+    if len(xdata) > data["every n dot"]:
+        plot_table = [
+            f"{x:{xformat}}{col_sep}{y:{ff}}{table_row_sep}" for x, y in zip(
+                xdata[::data["every n dot"]],
+                ydata[::data["every n dot"]])]
+    else:
+        plot_table = [
+            f"{x:{xformat}}{col_sep}{y:{ff}}{table_row_sep}" for x, y in zip(xdata, ydata)]
+
 
     min_extern_length = 3
 

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -101,7 +101,7 @@ def draw_line2d(data, obj):
     content += c
 
     if legend_text is not None:
-        legend_text_escaped = re.sub(r"(\d+(\.\d+)?)%",
+        legend_text_escaped = re.sub(r"(\d+(\.\d+)?)\s?%",
                                      r"\\SI{\1}{\\percent}",
                                      legend_text).replace("+-\\SI{",
                                      "\\SI{+-").replace(", s",

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -103,7 +103,9 @@ def draw_line2d(data, obj):
     if legend_text is not None:
         legend_text_escaped = re.sub(r"(\d+(\.\d+)?)%",
                                      r"\\SI{\1}{\\percent}",
-                                     legend_text).replace("+-\\SI{", "\\SI{+-")
+                                     legend_text).replace("+-\\SI{",
+                                     "\\SI{+-").replace(", s",
+                                     ", \\SI{\s}")
         content.append(f"\\addlegendentry{{{legend_text_escaped}}}\n")
 
     return data, content

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -279,7 +279,8 @@ def _table(obj, data):  # noqa: C901
             data["current axes"].axis_options.append("unbounded coords=jump")
 
     plot_table = [
-        f"{x:{xformat}}{col_sep}{y:{ff}}{table_row_sep}" for x, y in zip(xdata, ydata)
+        f"{x:{xformat}}{col_sep}{y:{ff}}{table_row_sep}" for x, y in zip(
+            xdata[::data["every n dot"]], ydata[::data["every n dot"]])
     ]
 
     min_extern_length = 3

--- a/src/tikzplotlib/_line2d.py
+++ b/src/tikzplotlib/_line2d.py
@@ -101,7 +101,9 @@ def draw_line2d(data, obj):
     content += c
 
     if legend_text is not None:
-        legend_text_escaped = re.sub(r"(\d+(\.\d+)?)%", r"\\SI{\1}{\\percent}", legend_text)
+        legend_text_escaped = re.sub(r"(\d+(\.\d+)?)%",
+                                     r"\\SI{\1}{\\percent}",
+                                     legend_text).replace("+-\\SI{", "\\SI{+-")
         content.append(f"\\addlegendentry{{{legend_text_escaped}}}\n")
 
     return data, content

--- a/src/tikzplotlib/_path.py
+++ b/src/tikzplotlib/_path.py
@@ -231,7 +231,7 @@ def draw_pathcollection(data, obj):
 
     is_contour = len(dd) == 1
     if is_contour:
-        draw_options = ["draw=none"]
+        draw_options = ["thick"]
 
     if marker0 is not None:
         data, pgfplots_marker, marker_options = _mpl_marker2pgfp_marker(

--- a/src/tikzplotlib/_path.py
+++ b/src/tikzplotlib/_path.py
@@ -303,7 +303,7 @@ def draw_pathcollection(data, obj):
 
         plot_table = []
         plot_table.append("  ".join(labels) + "\n")
-        for row in dd_strings:
+        for row in dd_strings[::data["every n dot"]]:
             plot_table.append(" ".join(row) + "\n")
 
         if data["externalize tables"]:

--- a/src/tikzplotlib/_path.py
+++ b/src/tikzplotlib/_path.py
@@ -468,9 +468,13 @@ def mpl_linestyle2pgfplots_linestyle(data, line_style, line=None):
         # get defaults
         default_dashOffset, default_dashSeq = mpl.lines._get_dash_pattern(line_style)
 
-        # get dash format of line under test
-        dashSeq = line._us_dashSeq
-        dashOffset = line._us_dashOffset
+        try:
+            # get dash format of line under test
+            dashSeq = line._us_dashSeq
+            dashOffset = line._us_dashOffset
+        except AttributeError:
+            dashSeq = default_dashSeq
+            dashOffset = default_dashOffset
 
         lst = list()
         if dashSeq != default_dashSeq:

--- a/src/tikzplotlib/_save.py
+++ b/src/tikzplotlib/_save.py
@@ -40,6 +40,7 @@ def get_tikz_code(
     float_format: str = ".15g",
     table_row_sep: str = "\n",
     flavor: str = "latex",
+    every_n_dot: int = 1,
 ):
     """Main function. Here, the recursion into the image starts and the
     contents are picked up. The actual file gets written in this routine.
@@ -136,6 +137,9 @@ def get_tikz_code(
                    Default is ``"latex"``.
     :type flavor: str
 
+    :param every_n_dot: if path is encountered, only draw every Nth dot
+    :type every_n_dot: int
+
     :returns: None
 
     The following optional attributes of matplotlib's objects are recognized
@@ -176,6 +180,7 @@ def get_tikz_code(
     data["legend colors"] = []
     data["add axis environment"] = add_axis_environment
     data["show_info"] = show_info
+    data["every n dot"] = every_n_dot
     # rectangle_legends is used to keep track of which rectangles have already
     # had \addlegendimage added. There should be only one \addlegenimage per
     # bar chart data series.

--- a/src/tikzplotlib/_save.py
+++ b/src/tikzplotlib/_save.py
@@ -41,6 +41,7 @@ def get_tikz_code(
     table_row_sep: str = "\n",
     flavor: str = "latex",
     every_n_dot: int = 1,
+    axis_equal: bool = False,
 ):
     """Main function. Here, the recursion into the image starts and the
     contents are picked up. The actual file gets written in this routine.
@@ -140,6 +141,9 @@ def get_tikz_code(
     :param every_n_dot: if path is encountered, only draw every Nth dot
     :type every_n_dot: int
 
+    :param axis_equal: if true, have equal axis ratio
+    :type axis_equal: bool
+
     :returns: None
 
     The following optional attributes of matplotlib's objects are recognized
@@ -181,6 +185,7 @@ def get_tikz_code(
     data["add axis environment"] = add_axis_environment
     data["show_info"] = show_info
     data["every n dot"] = every_n_dot
+    data["axis_equal"] = axis_equal
     # rectangle_legends is used to keep track of which rectangles have already
     # had \addlegendimage added. There should be only one \addlegenimage per
     # bar chart data series.

--- a/src/tikzplotlib/_text.py
+++ b/src/tikzplotlib/_text.py
@@ -59,7 +59,8 @@ def draw_text(data, obj):
 
         if obj.axes:
             # If the coordinates are relative to an axis, use `axis cs`.
-            tikz_pos = f"(axis cs:{pos[0]:{ff}},{pos[1]:{ff}})"
+            rel = "rel " if abs(pos[0]) < 1 and abs(pos[1]) < 1 else ""
+            tikz_pos = f"({rel}axis cs:{pos[0]:{ff}},{pos[1]:{ff}})"
         else:
             # relative to the entire figure, it's a getting a littler harder. See
             # <http://tex.stackexchange.com/a/274902/13262> for a solution to the

--- a/src/tikzplotlib/_text.py
+++ b/src/tikzplotlib/_text.py
@@ -35,9 +35,10 @@ def escape_text(text):
     The output will be: "The efficiency is \\SI{45}{\\percent} and
     the tolerance is \\SI{+-2}{\\degree}, \\SI{\s}"
     """
-    return re.sub(r"(\d+(\.\d+)?)\s?%", r"\\SI{\1}{\\percent}",
-                  text).replace("+-\\SI{", "\\SI{+-").replace(", s",
-                                ", \\SI{\\s}")
+    res_text = re.sub(r"(\d+(\.\d+)?)\s?%", r"\\SI{\1}{\\percent}", text)
+    res_text = re.sub(r"(\d+(\.\d+)?)\s?mm", r"\\SI{\1}{\\mm}", res_text)
+    res_text = re.sub(r"(\d+(\.\d+)?)\s?deg", r"\\SI{\1}{\\degree}", res_text)
+    return res_text.replace("+-\\SI{", "\\SI{+-").replace(", s", ", \\SI{\\s}")
 
 
 def draw_text(data, obj):

--- a/src/tikzplotlib/_text.py
+++ b/src/tikzplotlib/_text.py
@@ -1,7 +1,43 @@
 import matplotlib as mpl
+import re
 from matplotlib.patches import ArrowStyle
 
 from . import _color
+
+def escape_text(text):
+    """
+    Escapes certain patterns in a given text to make them compatible with
+    LaTeX formatting, especially for SI units.
+
+    Parameters:
+    - text (str): The input string that needs to be processed for LaTeX-
+    compatible escapes.
+
+    Returns:
+    - str: The text with escaped patterns suitable for LaTeX rendering.
+
+    The function primarily performs the following conversions:
+    1. Converts percentages, e.g., "45%", "45.5 %", to the LaTeX SI
+    unit format: "\\SI{45}{\\percent}".
+    2. Fixes potential issues with the "\\SI" unit for the plus-minus
+    notation.
+    3. Corrects ", s" patterns to ", \\SI{\\s}".
+
+    Note:
+    This function assumes that the input text is likely to contain numeric
+    values that need to be presented using SI notation in LaTeX. For
+    correct rendering, the siunitx LaTeX package should be included in
+    the document.
+
+    Example:
+    Given the input: "The efficiency is 45% and the tolerance is
+    +-\\SI{2}{\\degree}, s"
+    The output will be: "The efficiency is \\SI{45}{\\percent} and
+    the tolerance is \\SI{+-2}{\\degree}, \\SI{\s}"
+    """
+    return re.sub(r"(\d+(\.\d+)?)\s?%", r"\\SI{\1}{\\percent}",
+                  text).replace("+-\\SI{", "\\SI{+-").replace(", s",
+                                ", \\SI{\\s}")
 
 
 def draw_text(data, obj):

--- a/src/tikzplotlib/_text.py
+++ b/src/tikzplotlib/_text.py
@@ -151,7 +151,7 @@ def draw_text(data, obj):
         text = text.replace("\n ", "\\\\")
 
     props = ",\n  ".join(properties)
-    text = " ".join(style + [text])
+    text = escape_text(" ".join(style + [text])).replace("\n", "\\\\")
     content.append(f"\\draw {tikz_pos} node[\n  {props}\n]{{{text}}};\n")
     return data, content
 


### PR DESCRIPTION
`common_texification` is deprecated since matplotlib 3.6. I replaced with `tex_escape`.

See issue https://github.com/nschloe/tikzplotlib/issues/559 for more details.