### PR TITLE
Fix for `obj.get_subplotspec()` being None

### DIFF
--- a/src/tikzplotlib/_axes.py
+++ b/src/tikzplotlib/_axes.py
@@ -438,7 +438,11 @@ class Axes:
 
     def _subplot(self, obj, data):
         # https://github.com/matplotlib/matplotlib/issues/7225#issuecomment-252173667
-        geom = obj.get_subplotspec().get_topmost_subplotspec().get_geometry()
+        try:
+            geom = obj.get_subplotspec().get_topmost_subplotspec().get_geometry()
+        except AttributeError:
+            # obj.get_subplotspec() is sometimes None
+            return
 
         self.nsubplots = geom[0] * geom[1]
         if self.nsubplots > 1:


### PR DESCRIPTION
I can't be bothered to minimize a test-case for this right now, sorry.  Non-minimal test case at the bottom of https://gist.github.com/JasonGross/50bf9f6ccf8e1eff07fff2a35db703ee#file-l1-not-sparse-use-product-ipynb commit 981a0e4258b5dd566e784c00a98fbd30705f9438